### PR TITLE
Modularize JSX Types

### DIFF
--- a/packages/core/src/jsx/runtime.ts
+++ b/packages/core/src/jsx/runtime.ts
@@ -33,9 +33,8 @@ import type { ElementProps } from '../schema/index.js';
 import { EFFUSE_NODE, NodeType } from '../constants.js';
 import { el, fragment } from '../render/element.js';
 import { isBlueprint } from '../blueprint/blueprint.js';
-import type { Signal } from '../reactivity/signal.js';
-import type { ReadonlySignal } from '../types/index.js';
 import { UnknownJSXTypeError } from '../errors.js';
+import type { BaseIntrinsicElements } from './types/intrinsic.js';
 import { pipe, Predicate } from 'effect';
 
 interface FragmentProps {
@@ -43,6 +42,8 @@ interface FragmentProps {
 }
 
 const FragmentTag = Symbol.for('effuse.fragment');
+
+export type * from './types/index.js';
 
 export interface FragmentComponent {
 	(props: FragmentProps): EffuseNode;
@@ -165,220 +166,8 @@ export namespace JSX {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	export type LibraryManagedAttributes<_C, P> = P & IntrinsicAttributes;
 
-	export interface IntrinsicElements {
-		[key: string]: HTMLAttributes & Record<string, unknown>;
-	}
-
-	export interface HTMLAttributes {
-		key?: string | number | undefined;
-		ref?: ((el: unknown) => void) | undefined;
-		class?:
-			| string
-			| Record<string, boolean>
-			| (string | Record<string, boolean>)[]
-			| (() => string | undefined | null);
-		className?: string | (() => string | undefined | null);
-		style?:
-			| string
-			| Partial<CSSStyleDeclaration>
-			| (() => string | Partial<CSSStyleDeclaration>);
-		id?: string | (() => string);
-		title?: string | (() => string);
-		tabIndex?: number;
-		hidden?: boolean | (() => boolean);
-		children?: EffuseChild;
-
-		onClick?: (e: MouseEvent) => void;
-		onDblClick?: (e: MouseEvent) => void;
-		onMouseDown?: (e: MouseEvent) => void;
-		onMouseUp?: (e: MouseEvent) => void;
-		onMouseEnter?: (e: MouseEvent) => void;
-		onMouseLeave?: (e: MouseEvent) => void;
-		onMouseMove?: (e: MouseEvent) => void;
-		onKeyDown?: (e: KeyboardEvent) => void;
-		onKeyUp?: (e: KeyboardEvent) => void;
-		onKeyPress?: (e: KeyboardEvent) => void;
-		onFocus?: (e: FocusEvent) => void;
-		onBlur?: (e: FocusEvent) => void;
-		onInput?: (e: Event) => void;
-		onChange?: (e: Event) => void;
-		onSubmit?: (e: Event) => void;
-		onScroll?: (e: Event) => void;
-
-		[key: string]: unknown;
-	}
-
-	export interface AnchorAttributes extends HTMLAttributes {
-		href?: string;
-		target?: string;
-		rel?: string;
-		download?: string | boolean;
-	}
-
-	export interface ButtonAttributes extends HTMLAttributes {
-		type?: 'button' | 'submit' | 'reset';
-		disabled?:
-			| boolean
-			| Signal<boolean>
-			| ReadonlySignal<boolean>
-			| (() => boolean);
-	}
-
-	export interface InputAttributes extends HTMLAttributes {
-		type?: string;
-		value?: string | number | Signal<string> | Signal<number>;
-		checked?: boolean | Signal<boolean>;
-		disabled?: boolean;
-		placeholder?: string;
-		name?: string;
-		required?: boolean;
-		readonly?: boolean;
-		min?: string | number;
-		max?: string | number;
-		step?: string | number;
-		pattern?: string;
-		autoComplete?: string;
-		autoFocus?: boolean;
-	}
-
-	export interface FormAttributes extends HTMLAttributes {
-		action?: string;
-		method?: string;
-		encType?: string;
-		noValidate?: boolean;
-	}
-
-	export interface LabelAttributes extends HTMLAttributes {
-		for?: string;
-	}
-
-	export interface ImgAttributes extends HTMLAttributes {
-		src?: string;
-		alt?: string;
-		width?: number | string;
-		height?: number | string;
-		loading?: 'eager' | 'lazy';
-	}
-
-	export interface TextareaAttributes extends HTMLAttributes {
-		value?: string | Signal<string>;
-		placeholder?: string;
-		rows?: number;
-		cols?: number;
-		disabled?: boolean;
-		readonly?: boolean;
-		required?: boolean;
-	}
-
-	export interface SelectAttributes extends HTMLAttributes {
-		value?: string | Signal<string>;
-		disabled?: boolean;
-		multiple?: boolean;
-		required?: boolean;
-	}
-
-	export interface OptionAttributes extends HTMLAttributes {
-		value?: string;
-		selected?: boolean;
-		disabled?: boolean;
-	}
-
-	export interface CanvasAttributes extends HTMLAttributes {
-		width?: number | string;
-		height?: number | string;
-	}
-
-	export interface VideoAttributes extends HTMLAttributes {
-		src?: string;
-		autoPlay?: boolean;
-		controls?: boolean;
-		loop?: boolean;
-		muted?: boolean;
-		poster?: string;
-		width?: number | string;
-		height?: number | string;
-	}
-
-	export interface AudioAttributes extends HTMLAttributes {
-		src?: string;
-		autoPlay?: boolean;
-		controls?: boolean;
-		loop?: boolean;
-		muted?: boolean;
-	}
-
-	export interface IframeAttributes extends HTMLAttributes {
-		src?: string;
-		width?: number | string;
-		height?: number | string;
-		allow?: string;
-		sandbox?: string;
-	}
-
-	export interface SVGAttributes extends HTMLAttributes {
-		viewBox?: string;
-		xmlns?: string;
-		fill?: string;
-		stroke?: string;
-		strokeWidth?: number | string;
-	}
-
-	export interface SVGPathAttributes extends HTMLAttributes {
-		d?: string;
-		fill?: string;
-		stroke?: string;
-		strokeWidth?: number | string;
-	}
-
-	export interface IntrinsicElements {
-		div: HTMLAttributes;
-		span: HTMLAttributes;
-		p: HTMLAttributes;
-		a: AnchorAttributes;
-		button: ButtonAttributes;
-		input: InputAttributes;
-		form: FormAttributes;
-		label: LabelAttributes;
-		img: ImgAttributes;
-		ul: HTMLAttributes;
-		ol: HTMLAttributes;
-		li: HTMLAttributes;
-		h1: HTMLAttributes;
-		h2: HTMLAttributes;
-		h3: HTMLAttributes;
-		h4: HTMLAttributes;
-		h5: HTMLAttributes;
-		h6: HTMLAttributes;
-		header: HTMLAttributes;
-		footer: HTMLAttributes;
-		main: HTMLAttributes;
-		section: HTMLAttributes;
-		article: HTMLAttributes;
-		nav: HTMLAttributes;
-		aside: HTMLAttributes;
-		table: HTMLAttributes;
-		thead: HTMLAttributes;
-		tbody: HTMLAttributes;
-		tr: HTMLAttributes;
-		th: HTMLAttributes;
-		td: HTMLAttributes;
-		textarea: TextareaAttributes;
-		select: SelectAttributes;
-		option: OptionAttributes;
-		br: HTMLAttributes;
-		hr: HTMLAttributes;
-		strong: HTMLAttributes;
-		em: HTMLAttributes;
-		code: HTMLAttributes;
-		pre: HTMLAttributes;
-		blockquote: HTMLAttributes;
-		canvas: CanvasAttributes;
-		video: VideoAttributes;
-		audio: AudioAttributes;
-		iframe: IframeAttributes;
-		svg: SVGAttributes;
-		path: SVGPathAttributes;
-	}
+	// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+	export interface IntrinsicElements extends BaseIntrinsicElements {}
 
 	export interface ElementChildrenAttribute {
 		children: unknown;

--- a/packages/core/src/jsx/types/aria.ts
+++ b/packages/core/src/jsx/types/aria.ts
@@ -1,0 +1,195 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import type { Signal } from '../../reactivity/signal.js';
+import type { ReadonlySignal } from '../../types/index.js';
+
+// Reactive boolean type for ARIA attributes that can be bound to signals/functions
+type ReactiveBoolean =
+	| boolean
+	| 'true'
+	| 'false'
+	| Signal<boolean>
+	| ReadonlySignal<boolean>
+	| (() => boolean);
+
+export interface AriaAttributes {
+	// Widget Attributes
+	'aria-autocomplete'?: 'none' | 'inline' | 'list' | 'both';
+	'aria-checked'?: ReactiveBoolean | 'mixed';
+	'aria-disabled'?: ReactiveBoolean;
+	'aria-errormessage'?: string;
+	'aria-expanded'?: ReactiveBoolean;
+	'aria-haspopup'?:
+		| boolean
+		| 'true'
+		| 'false'
+		| 'menu'
+		| 'listbox'
+		| 'tree'
+		| 'grid'
+		| 'dialog';
+	'aria-hidden'?: ReactiveBoolean;
+	'aria-invalid'?: boolean | 'true' | 'false' | 'grammar' | 'spelling';
+	'aria-label'?: string;
+	'aria-level'?: number;
+	'aria-modal'?: ReactiveBoolean;
+	'aria-multiline'?: ReactiveBoolean;
+	'aria-multiselectable'?: ReactiveBoolean;
+	'aria-orientation'?: 'horizontal' | 'vertical';
+	'aria-placeholder'?: string;
+	'aria-pressed'?: ReactiveBoolean | 'mixed';
+	'aria-readonly'?: ReactiveBoolean;
+	'aria-required'?: ReactiveBoolean;
+	'aria-selected'?: ReactiveBoolean;
+	'aria-sort'?: 'none' | 'ascending' | 'descending' | 'other';
+	'aria-valuemax'?: number;
+	'aria-valuemin'?: number;
+	'aria-valuenow'?: number;
+	'aria-valuetext'?: string;
+
+	// Live Region Attributes
+	'aria-atomic'?: ReactiveBoolean;
+	'aria-busy'?: ReactiveBoolean;
+	'aria-live'?: 'off' | 'polite' | 'assertive';
+	'aria-relevant'?:
+		| 'additions'
+		| 'additions removals'
+		| 'additions text'
+		| 'all'
+		| 'removals'
+		| 'removals additions'
+		| 'removals text'
+		| 'text'
+		| 'text additions'
+		| 'text removals';
+
+	// Drag-and-Drop Attributes
+	'aria-dropeffect'?: 'none' | 'copy' | 'execute' | 'link' | 'move' | 'popup';
+	'aria-grabbed'?: ReactiveBoolean;
+
+	// Relationship Attributes
+	'aria-activedescendant'?: string;
+	'aria-colcount'?: number;
+	'aria-colindex'?: number;
+	'aria-colspan'?: number;
+	'aria-controls'?: string;
+	'aria-describedby'?: string;
+	'aria-details'?: string;
+	'aria-flowto'?: string;
+	'aria-keyshortcuts'?: string;
+	'aria-labelledby'?: string;
+	'aria-owns'?: string;
+	'aria-posinset'?: number;
+	'aria-roledescription'?: string;
+	'aria-rowcount'?: number;
+	'aria-rowindex'?: number;
+	'aria-rowspan'?: number;
+	'aria-setsize'?: number;
+
+	// Current State
+	'aria-current'?:
+		| boolean
+		| 'true'
+		| 'false'
+		| 'page'
+		| 'step'
+		| 'location'
+		| 'date'
+		| 'time';
+
+	// Role attribute (WAI-ARIA roles)
+	role?:
+		| 'alert'
+		| 'alertdialog'
+		| 'application'
+		| 'article'
+		| 'banner'
+		| 'button'
+		| 'cell'
+		| 'checkbox'
+		| 'columnheader'
+		| 'combobox'
+		| 'complementary'
+		| 'contentinfo'
+		| 'definition'
+		| 'dialog'
+		| 'directory'
+		| 'document'
+		| 'feed'
+		| 'figure'
+		| 'form'
+		| 'grid'
+		| 'gridcell'
+		| 'group'
+		| 'heading'
+		| 'img'
+		| 'link'
+		| 'list'
+		| 'listbox'
+		| 'listitem'
+		| 'log'
+		| 'main'
+		| 'marquee'
+		| 'math'
+		| 'menu'
+		| 'menubar'
+		| 'menuitem'
+		| 'menuitemcheckbox'
+		| 'menuitemradio'
+		| 'meter'
+		| 'navigation'
+		| 'none'
+		| 'note'
+		| 'option'
+		| 'presentation'
+		| 'progressbar'
+		| 'radio'
+		| 'radiogroup'
+		| 'region'
+		| 'row'
+		| 'rowgroup'
+		| 'rowheader'
+		| 'scrollbar'
+		| 'search'
+		| 'searchbox'
+		| 'separator'
+		| 'slider'
+		| 'spinbutton'
+		| 'status'
+		| 'switch'
+		| 'tab'
+		| 'table'
+		| 'tablist'
+		| 'tabpanel'
+		| 'term'
+		| 'textbox'
+		| 'timer'
+		| 'toolbar'
+		| 'tooltip'
+		| 'tree'
+		| 'treegrid'
+		| 'treeitem'
+		| (string & {});
+}

--- a/packages/core/src/jsx/types/elements.ts
+++ b/packages/core/src/jsx/types/elements.ts
@@ -1,0 +1,537 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import type { Signal } from '../../reactivity/signal.js';
+import type { ReadonlySignal } from '../../types/index.js';
+import type { HTMLAttributes } from './html.js';
+import type {
+	InputType,
+	ButtonType,
+	AnchorTarget,
+	FormMethod,
+	FormEncType,
+	AutoComplete,
+	LoadingBehavior,
+	DecodingBehavior,
+	PreloadBehavior,
+	CrossOrigin,
+	TextWrap,
+	TableScope,
+	ReferrerPolicy,
+} from './unions.js';
+
+export interface AnchorAttributes extends HTMLAttributes {
+	href?: string;
+	target?: AnchorTarget;
+	rel?: string;
+	download?: string | boolean;
+	hreflang?: string;
+	ping?: string;
+	referrerPolicy?: ReferrerPolicy;
+	type?: string;
+}
+
+export interface ButtonAttributes extends HTMLAttributes {
+	type?: ButtonType;
+	disabled?:
+		| boolean
+		| Signal<boolean>
+		| ReadonlySignal<boolean>
+		| (() => boolean);
+	name?: string;
+	value?: string;
+	form?: string;
+	formAction?: string;
+	formEncType?: FormEncType;
+	formMethod?: FormMethod;
+	formNoValidate?: boolean;
+	formTarget?: AnchorTarget;
+}
+
+export interface InputAttributes extends HTMLAttributes {
+	type?: InputType;
+	value?:
+		| string
+		| number
+		| Signal<string>
+		| Signal<number>
+		| ReadonlySignal<string>
+		| ReadonlySignal<number>;
+	checked?: boolean | Signal<boolean> | ReadonlySignal<boolean>;
+	disabled?:
+		| boolean
+		| Signal<boolean>
+		| ReadonlySignal<boolean>
+		| (() => boolean);
+	placeholder?: string;
+	name?: string;
+	required?: boolean;
+	readonly?: boolean;
+	min?: string | number;
+	max?: string | number;
+	step?: string | number;
+	pattern?: string;
+	autoComplete?: AutoComplete;
+	autoFocus?: boolean;
+	maxLength?: number;
+	minLength?: number;
+	size?: number;
+	multiple?: boolean;
+	accept?: string;
+	capture?: 'user' | 'environment';
+	list?: string;
+	form?: string;
+	formAction?: string;
+	formEncType?: FormEncType;
+	formMethod?: FormMethod;
+	formNoValidate?: boolean;
+	formTarget?: AnchorTarget;
+	height?: number | string;
+	width?: number | string;
+	src?: string;
+	alt?: string;
+	dirname?: string;
+}
+
+export interface TextareaAttributes extends HTMLAttributes {
+	value?: string | Signal<string> | ReadonlySignal<string>;
+	defaultValue?: string;
+	placeholder?: string;
+	rows?: number;
+	cols?: number;
+	disabled?:
+		| boolean
+		| Signal<boolean>
+		| ReadonlySignal<boolean>
+		| (() => boolean);
+	readonly?: boolean;
+	required?: boolean;
+	maxLength?: number;
+	minLength?: number;
+	wrap?: TextWrap;
+	autoComplete?: AutoComplete;
+	autoFocus?: boolean;
+	name?: string;
+	form?: string;
+	dirname?: string;
+}
+
+export interface SelectAttributes extends HTMLAttributes {
+	value?: string | Signal<string> | ReadonlySignal<string>;
+	disabled?:
+		| boolean
+		| Signal<boolean>
+		| ReadonlySignal<boolean>
+		| (() => boolean);
+	multiple?: boolean;
+	required?: boolean;
+	size?: number;
+	name?: string;
+	form?: string;
+	autoComplete?: AutoComplete;
+	autoFocus?: boolean;
+}
+
+export interface OptionAttributes extends HTMLAttributes {
+	value?: string;
+	selected?: boolean;
+	disabled?: boolean;
+	label?: string;
+}
+
+export interface OptgroupAttributes extends HTMLAttributes {
+	disabled?: boolean;
+	label?: string;
+}
+
+export interface FormAttributes extends HTMLAttributes {
+	action?: string;
+	method?: FormMethod;
+	encType?: FormEncType;
+	noValidate?: boolean;
+	target?: AnchorTarget;
+	autoComplete?: 'on' | 'off';
+	name?: string;
+	rel?: string;
+	acceptCharset?: string;
+}
+
+export interface LabelAttributes extends HTMLAttributes {
+	for?: string;
+	htmlFor?: string;
+}
+
+export interface FieldsetAttributes extends HTMLAttributes {
+	disabled?: boolean;
+	form?: string;
+	name?: string;
+}
+
+export interface OutputAttributes extends HTMLAttributes {
+	for?: string;
+	form?: string;
+	name?: string;
+}
+
+export interface ProgressAttributes extends HTMLAttributes {
+	value?: number;
+	max?: number;
+}
+
+export interface MeterAttributes extends HTMLAttributes {
+	value?: number;
+	min?: number;
+	max?: number;
+	low?: number;
+	high?: number;
+	optimum?: number;
+}
+
+export interface ImgAttributes extends HTMLAttributes {
+	src?: string;
+	alt?: string;
+	width?: number | string;
+	height?: number | string;
+	loading?: LoadingBehavior;
+	decoding?: DecodingBehavior;
+	srcSet?: string;
+	sizes?: string;
+	crossOrigin?: CrossOrigin;
+	referrerPolicy?: ReferrerPolicy;
+	isMap?: boolean;
+	useMap?: string;
+	fetchPriority?: 'high' | 'low' | 'auto';
+}
+
+export interface VideoAttributes extends HTMLAttributes {
+	src?: string;
+	autoPlay?: boolean;
+	controls?: boolean;
+	loop?: boolean;
+	muted?: boolean;
+	poster?: string;
+	width?: number | string;
+	height?: number | string;
+	preload?: PreloadBehavior;
+	playsInline?: boolean;
+	crossOrigin?: CrossOrigin;
+	disablePictureInPicture?: boolean;
+	disableRemotePlayback?: boolean;
+}
+
+export interface AudioAttributes extends HTMLAttributes {
+	src?: string;
+	autoPlay?: boolean;
+	controls?: boolean;
+	loop?: boolean;
+	muted?: boolean;
+	preload?: PreloadBehavior;
+	crossOrigin?: CrossOrigin;
+	disableRemotePlayback?: boolean;
+}
+
+export interface SourceAttributes extends HTMLAttributes {
+	src?: string;
+	srcSet?: string;
+	media?: string;
+	sizes?: string;
+	type?: string;
+	width?: number;
+	height?: number;
+}
+
+export interface TrackAttributes extends HTMLAttributes {
+	default?: boolean;
+	kind?: 'subtitles' | 'captions' | 'descriptions' | 'chapters' | 'metadata';
+	label?: string;
+	src?: string;
+	srclang?: string;
+}
+
+export interface CanvasAttributes extends HTMLAttributes {
+	width?: number | string;
+	height?: number | string;
+}
+
+export interface IframeAttributes extends HTMLAttributes {
+	src?: string;
+	srcdoc?: string;
+	width?: number | string;
+	height?: number | string;
+	allow?: string;
+	sandbox?: string;
+	loading?: LoadingBehavior;
+	referrerPolicy?: ReferrerPolicy;
+	name?: string;
+	allowFullscreen?: boolean;
+}
+
+export interface EmbedAttributes extends HTMLAttributes {
+	src?: string;
+	type?: string;
+	width?: number | string;
+	height?: number | string;
+}
+
+export interface ObjectAttributes extends HTMLAttributes {
+	data?: string;
+	type?: string;
+	name?: string;
+	useMap?: string;
+	form?: string;
+	width?: number | string;
+	height?: number | string;
+}
+
+export interface TableAttributes extends HTMLAttributes {
+	cellPadding?: number | string;
+	cellSpacing?: number | string;
+	border?: number | string;
+}
+
+export interface ThAttributes extends HTMLAttributes {
+	colSpan?: number;
+	rowSpan?: number;
+	scope?: TableScope;
+	headers?: string;
+	abbr?: string;
+}
+
+export interface TdAttributes extends HTMLAttributes {
+	colSpan?: number;
+	rowSpan?: number;
+	headers?: string;
+}
+
+export interface ColAttributes extends HTMLAttributes {
+	span?: number;
+}
+
+export interface ColgroupAttributes extends HTMLAttributes {
+	span?: number;
+}
+
+export interface MetaAttributes extends HTMLAttributes {
+	charSet?: string;
+	content?: string;
+	httpEquiv?:
+		| 'content-type'
+		| 'default-style'
+		| 'refresh'
+		| 'x-ua-compatible'
+		| (string & {});
+	name?: string;
+	media?: string;
+}
+
+export interface LinkAttributes extends HTMLAttributes {
+	href?: string;
+	rel?: string;
+	type?: string;
+	media?: string;
+	as?:
+		| 'audio'
+		| 'document'
+		| 'embed'
+		| 'fetch'
+		| 'font'
+		| 'image'
+		| 'object'
+		| 'script'
+		| 'style'
+		| 'track'
+		| 'video'
+		| 'worker';
+	crossOrigin?: CrossOrigin;
+	integrity?: string;
+	referrerPolicy?: ReferrerPolicy;
+	sizes?: string;
+	disabled?: boolean;
+	hreflang?: string;
+	title?: string;
+	fetchPriority?: 'high' | 'low' | 'auto';
+	blocking?: 'render';
+}
+
+export interface StyleAttributes extends HTMLAttributes {
+	media?: string;
+	blocking?: 'render';
+}
+
+export interface ScriptAttributes extends HTMLAttributes {
+	src?: string;
+	type?: 'module' | 'importmap' | (string & {});
+	async?: boolean;
+	defer?: boolean;
+	crossOrigin?: CrossOrigin;
+	integrity?: string;
+	noModule?: boolean;
+	nonce?: string;
+	referrerPolicy?: ReferrerPolicy;
+	blocking?: 'render';
+	fetchPriority?: 'high' | 'low' | 'auto';
+}
+
+export interface BaseAttributes extends HTMLAttributes {
+	href?: string;
+	target?: AnchorTarget;
+}
+
+export interface DetailsAttributes extends HTMLAttributes {
+	open?: boolean;
+}
+
+export interface DialogAttributes extends HTMLAttributes {
+	open?: boolean;
+}
+
+export type SummaryAttributes = HTMLAttributes;
+
+export type MenuAttributes = HTMLAttributes;
+
+export interface SVGAttributes extends HTMLAttributes {
+	viewBox?: string;
+	xmlns?: string;
+	fill?: string;
+	stroke?: string;
+	strokeWidth?: number | string;
+	width?: number | string;
+	height?: number | string;
+	preserveAspectRatio?: string;
+	x?: number | string;
+	y?: number | string;
+}
+
+export interface SVGPathAttributes extends HTMLAttributes {
+	d?: string;
+	fill?: string;
+	stroke?: string;
+	strokeWidth?: number | string;
+	strokeLinecap?: 'butt' | 'round' | 'square';
+	strokeLinejoin?: 'miter' | 'round' | 'bevel';
+	strokeDasharray?: string | number;
+	strokeDashoffset?: string | number;
+	fillRule?: 'nonzero' | 'evenodd';
+	clipRule?: 'nonzero' | 'evenodd';
+	transform?: string;
+	opacity?: number | string;
+	pathLength?: number;
+}
+
+export interface SVGCircleAttributes extends SVGAttributes {
+	cx?: number | string;
+	cy?: number | string;
+	r?: number | string;
+}
+
+export interface SVGEllipseAttributes extends SVGAttributes {
+	cx?: number | string;
+	cy?: number | string;
+	rx?: number | string;
+	ry?: number | string;
+}
+
+export interface SVGLineAttributes extends SVGAttributes {
+	x1?: number | string;
+	y1?: number | string;
+	x2?: number | string;
+	y2?: number | string;
+}
+
+export interface SVGRectAttributes extends SVGAttributes {
+	x?: number | string;
+	y?: number | string;
+	width?: number | string;
+	height?: number | string;
+	rx?: number | string;
+	ry?: number | string;
+}
+
+export interface SVGPolygonAttributes extends SVGAttributes {
+	points?: string;
+}
+
+export interface SVGPolylineAttributes extends SVGAttributes {
+	points?: string;
+}
+
+export interface SVGTextAttributes extends SVGAttributes {
+	x?: number | string;
+	y?: number | string;
+	dx?: number | string;
+	dy?: number | string;
+	textAnchor?: 'start' | 'middle' | 'end';
+	dominantBaseline?: string;
+}
+
+export interface SVGUseAttributes extends SVGAttributes {
+	href?: string;
+	'xlink:href'?: string;
+}
+
+export interface SlotAttributes extends HTMLAttributes {
+	name?: string;
+}
+
+export interface TemplateAttributes extends HTMLAttributes {
+	shadowrootmode?: 'open' | 'closed';
+}
+
+export interface AreaAttributes extends HTMLAttributes {
+	alt?: string;
+	coords?: string;
+	download?: string | boolean;
+	href?: string;
+	ping?: string;
+	referrerPolicy?: ReferrerPolicy;
+	rel?: string;
+	shape?: 'rect' | 'circle' | 'poly' | 'default';
+	target?: AnchorTarget;
+}
+
+export interface MapAttributes extends HTMLAttributes {
+	name?: string;
+}
+
+export interface QuoteAttributes extends HTMLAttributes {
+	cite?: string;
+}
+
+export interface TimeAttributes extends HTMLAttributes {
+	dateTime?: string;
+}
+
+export interface DataAttributes extends HTMLAttributes {
+	value?: string;
+}
+
+export interface DelAttributes extends HTMLAttributes {
+	cite?: string;
+	dateTime?: string;
+}
+
+export interface InsAttributes extends HTMLAttributes {
+	cite?: string;
+	dateTime?: string;
+}

--- a/packages/core/src/jsx/types/events.ts
+++ b/packages/core/src/jsx/types/events.ts
@@ -1,0 +1,169 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import type { EffuseChild } from '../../render/node.js';
+
+export interface DOMAttributes {
+	children?: EffuseChild;
+
+	// Clipboard Events
+	onCopy?: (e: ClipboardEvent) => void;
+	onCut?: (e: ClipboardEvent) => void;
+	onPaste?: (e: ClipboardEvent) => void;
+
+	// Composition Events
+	onCompositionEnd?: (e: CompositionEvent) => void;
+	onCompositionStart?: (e: CompositionEvent) => void;
+	onCompositionUpdate?: (e: CompositionEvent) => void;
+
+	// Focus Events
+	onFocus?: (e: FocusEvent) => void;
+	onBlur?: (e: FocusEvent) => void;
+	onFocusIn?: (e: FocusEvent) => void;
+	onFocusOut?: (e: FocusEvent) => void;
+
+	// Form Events
+	onChange?: (e: Event) => void;
+	onInput?: (e: Event) => void;
+	onReset?: (e: Event) => void;
+	onSubmit?: (e: SubmitEvent) => void;
+	onInvalid?: (e: Event) => void;
+	onFormData?: (e: FormDataEvent) => void;
+
+	// Image Events
+	onLoad?: (e: Event) => void;
+	onError?: (e: Event | string) => void;
+
+	// Keyboard Events
+	onKeyDown?: (e: KeyboardEvent) => void;
+	onKeyPress?: (e: KeyboardEvent) => void;
+	onKeyUp?: (e: KeyboardEvent) => void;
+
+	// Mouse Events
+	onClick?: (e: MouseEvent) => void;
+	onContextMenu?: (e: MouseEvent) => void;
+	onDblClick?: (e: MouseEvent) => void;
+	onMouseDown?: (e: MouseEvent) => void;
+	onMouseEnter?: (e: MouseEvent) => void;
+	onMouseLeave?: (e: MouseEvent) => void;
+	onMouseMove?: (e: MouseEvent) => void;
+	onMouseOut?: (e: MouseEvent) => void;
+	onMouseOver?: (e: MouseEvent) => void;
+	onMouseUp?: (e: MouseEvent) => void;
+	onAuxClick?: (e: MouseEvent) => void;
+
+	// Pointer Events
+	onPointerDown?: (e: PointerEvent) => void;
+	onPointerMove?: (e: PointerEvent) => void;
+	onPointerUp?: (e: PointerEvent) => void;
+	onPointerCancel?: (e: PointerEvent) => void;
+	onPointerEnter?: (e: PointerEvent) => void;
+	onPointerLeave?: (e: PointerEvent) => void;
+	onPointerOver?: (e: PointerEvent) => void;
+	onPointerOut?: (e: PointerEvent) => void;
+	onGotPointerCapture?: (e: PointerEvent) => void;
+	onLostPointerCapture?: (e: PointerEvent) => void;
+
+	// Touch Events
+	onTouchCancel?: (e: TouchEvent) => void;
+	onTouchEnd?: (e: TouchEvent) => void;
+	onTouchMove?: (e: TouchEvent) => void;
+	onTouchStart?: (e: TouchEvent) => void;
+
+	// Drag Events
+	onDrag?: (e: DragEvent) => void;
+	onDragEnd?: (e: DragEvent) => void;
+	onDragEnter?: (e: DragEvent) => void;
+	onDragExit?: (e: DragEvent) => void;
+	onDragLeave?: (e: DragEvent) => void;
+	onDragOver?: (e: DragEvent) => void;
+	onDragStart?: (e: DragEvent) => void;
+	onDrop?: (e: DragEvent) => void;
+
+	// Scroll Events
+	onScroll?: (e: Event) => void;
+	onScrollEnd?: (e: Event) => void;
+
+	// Wheel Events
+	onWheel?: (e: WheelEvent) => void;
+
+	// Animation Events
+	onAnimationStart?: (e: AnimationEvent) => void;
+	onAnimationEnd?: (e: AnimationEvent) => void;
+	onAnimationIteration?: (e: AnimationEvent) => void;
+	onAnimationCancel?: (e: AnimationEvent) => void;
+
+	// Transition Events
+	onTransitionStart?: (e: TransitionEvent) => void;
+	onTransitionEnd?: (e: TransitionEvent) => void;
+	onTransitionRun?: (e: TransitionEvent) => void;
+	onTransitionCancel?: (e: TransitionEvent) => void;
+
+	// Selection Events
+	onSelect?: (e: Event) => void;
+	onSelectionChange?: (e: Event) => void;
+
+	// Media Events
+	onAbort?: (e: Event) => void;
+	onCanPlay?: (e: Event) => void;
+	onCanPlayThrough?: (e: Event) => void;
+	onDurationChange?: (e: Event) => void;
+	onEmptied?: (e: Event) => void;
+	onEnded?: (e: Event) => void;
+	onLoadedData?: (e: Event) => void;
+	onLoadedMetadata?: (e: Event) => void;
+	onLoadStart?: (e: Event) => void;
+	onPause?: (e: Event) => void;
+	onPlay?: (e: Event) => void;
+	onPlaying?: (e: Event) => void;
+	onProgress?: (e: ProgressEvent) => void;
+	onRateChange?: (e: Event) => void;
+	onSeeked?: (e: Event) => void;
+	onSeeking?: (e: Event) => void;
+	onStalled?: (e: Event) => void;
+	onSuspend?: (e: Event) => void;
+	onTimeUpdate?: (e: Event) => void;
+	onVolumeChange?: (e: Event) => void;
+	onWaiting?: (e: Event) => void;
+
+	// Toggle Events (for details element)
+	onToggle?: (e: Event) => void;
+
+	// Fullscreen Events
+	onFullscreenChange?: (e: Event) => void;
+	onFullscreenError?: (e: Event) => void;
+
+	// Picture-in-Picture Events
+	onEnterPictureInPicture?: (e: Event) => void;
+	onLeavePictureInPicture?: (e: Event) => void;
+
+	// Resize Events
+	onResize?: (e: UIEvent) => void;
+
+	// Security Events
+	onSecurityPolicyViolation?: (e: SecurityPolicyViolationEvent) => void;
+
+	// Slot Events
+	onSlotChange?: (e: Event) => void;
+}

--- a/packages/core/src/jsx/types/html.ts
+++ b/packages/core/src/jsx/types/html.ts
@@ -1,0 +1,118 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import type { AriaAttributes } from './aria.js';
+import type { DOMAttributes } from './events.js';
+import type {
+	TextDirection,
+	ContentEditable,
+	InputMode,
+	EnterKeyHint,
+	AutoCapitalize,
+	PopoverType,
+	PopoverTargetAction,
+} from './unions.js';
+
+export interface HTMLAttributes extends AriaAttributes, DOMAttributes {
+	// Core Attributes
+	key?: string | number | undefined;
+	ref?: ((el: unknown) => void) | undefined;
+
+	// Identifiers
+	id?: string | (() => string);
+
+	// Class / Styling
+	class?:
+		| string
+		| Record<string, boolean>
+		| (string | Record<string, boolean>)[]
+		| (() => string | undefined | null);
+	className?: string | (() => string | undefined | null);
+	style?:
+		| string
+		| Partial<CSSStyleDeclaration>
+		| (() => string | Partial<CSSStyleDeclaration>);
+
+	// Text Content
+	title?: string | (() => string);
+
+	// Tab Navigation
+	tabIndex?: number;
+
+	// Visibility
+	hidden?: boolean | 'hidden' | 'until-found' | (() => boolean);
+
+	// Language
+	lang?: string;
+	dir?: TextDirection;
+	translate?: 'yes' | 'no';
+
+	// Editing
+	contentEditable?: ContentEditable;
+	spellcheck?: boolean | 'true' | 'false';
+
+	// Interaction
+	draggable?: boolean | 'true' | 'false';
+	enterKeyHint?: EnterKeyHint;
+	inputMode?: InputMode;
+
+	// Accessibility
+	accessKey?: string;
+
+	// Custom Data Attributes
+	[key: `data-${string}`]: unknown;
+
+	// Slot (Web Components)
+	slot?: string;
+
+	// Nonce (CSP)
+	nonce?: string;
+
+	// Part (CSS Shadow Parts)
+	part?: string;
+
+	// Popover API
+	popover?: PopoverType;
+	popoverTarget?: string;
+	popoverTargetAction?: PopoverTargetAction;
+
+	// Inert
+	inert?: boolean;
+
+	// Autocapitalize
+	autocapitalize?: AutoCapitalize;
+
+	// Autofocus (global in HTML5.2+)
+	autofocus?: boolean;
+
+	// Item Scope (Microdata)
+	itemscope?: boolean;
+	itemprop?: string;
+	itemtype?: string;
+	itemid?: string;
+	itemref?: string;
+
+	// Allow unknown props
+	[key: string]: unknown;
+}

--- a/packages/core/src/jsx/types/index.ts
+++ b/packages/core/src/jsx/types/index.ts
@@ -1,0 +1,111 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+export type {
+	InputType,
+	ButtonType,
+	AnchorTarget,
+	FormMethod,
+	FormEncType,
+	AutoComplete,
+	LoadingBehavior,
+	DecodingBehavior,
+	PreloadBehavior,
+	CrossOrigin,
+	TextDirection,
+	ContentEditable,
+	InputMode,
+	EnterKeyHint,
+	TextWrap,
+	TableScope,
+	ReferrerPolicy,
+	AutoCapitalize,
+	PopoverType,
+	PopoverTargetAction,
+} from './unions.js';
+
+export type { AriaAttributes } from './aria.js';
+
+export type { DOMAttributes } from './events.js';
+export type { HTMLAttributes } from './html.js';
+
+export type {
+	AnchorAttributes,
+	ButtonAttributes,
+	InputAttributes,
+	TextareaAttributes,
+	SelectAttributes,
+	OptionAttributes,
+	OptgroupAttributes,
+	FormAttributes,
+	LabelAttributes,
+	FieldsetAttributes,
+	OutputAttributes,
+	ProgressAttributes,
+	MeterAttributes,
+	ImgAttributes,
+	VideoAttributes,
+	AudioAttributes,
+	SourceAttributes,
+	TrackAttributes,
+	CanvasAttributes,
+	IframeAttributes,
+	EmbedAttributes,
+	ObjectAttributes,
+	TableAttributes,
+	ThAttributes,
+	TdAttributes,
+	ColAttributes,
+	ColgroupAttributes,
+	MetaAttributes,
+	LinkAttributes,
+	StyleAttributes,
+	ScriptAttributes,
+	BaseAttributes,
+	DetailsAttributes,
+	DialogAttributes,
+	SummaryAttributes,
+	MenuAttributes,
+	SVGAttributes,
+	SVGPathAttributes,
+	SVGCircleAttributes,
+	SVGEllipseAttributes,
+	SVGLineAttributes,
+	SVGRectAttributes,
+	SVGPolygonAttributes,
+	SVGPolylineAttributes,
+	SVGTextAttributes,
+	SVGUseAttributes,
+	SlotAttributes,
+	TemplateAttributes,
+	AreaAttributes,
+	MapAttributes,
+	QuoteAttributes,
+	TimeAttributes,
+	DataAttributes,
+	DelAttributes,
+	InsAttributes,
+} from './elements.js';
+
+export type { BaseIntrinsicElements as IntrinsicElements } from './intrinsic.js';

--- a/packages/core/src/jsx/types/intrinsic.ts
+++ b/packages/core/src/jsx/types/intrinsic.ts
@@ -1,0 +1,308 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import type { HTMLAttributes } from './html.js';
+import type {
+	AnchorAttributes,
+	ButtonAttributes,
+	InputAttributes,
+	TextareaAttributes,
+	SelectAttributes,
+	OptionAttributes,
+	OptgroupAttributes,
+	FormAttributes,
+	LabelAttributes,
+	FieldsetAttributes,
+	OutputAttributes,
+	ProgressAttributes,
+	MeterAttributes,
+	ImgAttributes,
+	VideoAttributes,
+	AudioAttributes,
+	SourceAttributes,
+	TrackAttributes,
+	CanvasAttributes,
+	IframeAttributes,
+	EmbedAttributes,
+	ObjectAttributes,
+	TableAttributes,
+	ThAttributes,
+	TdAttributes,
+	ColAttributes,
+	ColgroupAttributes,
+	MetaAttributes,
+	LinkAttributes,
+	StyleAttributes,
+	ScriptAttributes,
+	BaseAttributes,
+	DetailsAttributes,
+	DialogAttributes,
+	SVGAttributes,
+	SVGPathAttributes,
+	SVGCircleAttributes,
+	SVGEllipseAttributes,
+	SVGLineAttributes,
+	SVGRectAttributes,
+	SVGPolygonAttributes,
+	SVGPolylineAttributes,
+	SVGTextAttributes,
+	SVGUseAttributes,
+	SlotAttributes,
+	TemplateAttributes,
+	AreaAttributes,
+	MapAttributes,
+	QuoteAttributes,
+	TimeAttributes,
+	DataAttributes,
+	DelAttributes,
+	InsAttributes,
+} from './elements.js';
+
+export interface BaseIntrinsicElements {
+	// Document Metadata
+	html: HTMLAttributes;
+	head: HTMLAttributes;
+	title: HTMLAttributes;
+	base: BaseAttributes;
+	link: LinkAttributes;
+	meta: MetaAttributes;
+	style: StyleAttributes;
+
+	// Sectioning Root
+	body: HTMLAttributes;
+
+	// Content Sectioning
+	article: HTMLAttributes;
+	section: HTMLAttributes;
+	nav: HTMLAttributes;
+	aside: HTMLAttributes;
+	header: HTMLAttributes;
+	footer: HTMLAttributes;
+	main: HTMLAttributes;
+	address: HTMLAttributes;
+	hgroup: HTMLAttributes;
+	search: HTMLAttributes;
+
+	// Heading Content
+	h1: HTMLAttributes;
+	h2: HTMLAttributes;
+	h3: HTMLAttributes;
+	h4: HTMLAttributes;
+	h5: HTMLAttributes;
+	h6: HTMLAttributes;
+
+	// Text Content
+	div: HTMLAttributes;
+	p: HTMLAttributes;
+	blockquote: QuoteAttributes;
+	ol: HTMLAttributes;
+	ul: HTMLAttributes;
+	li: HTMLAttributes;
+	dl: HTMLAttributes;
+	dt: HTMLAttributes;
+	dd: HTMLAttributes;
+	figure: HTMLAttributes;
+	figcaption: HTMLAttributes;
+	hr: HTMLAttributes;
+	pre: HTMLAttributes;
+	menu: HTMLAttributes;
+
+	// Inline Text Semantics
+	a: AnchorAttributes;
+	abbr: HTMLAttributes;
+	b: HTMLAttributes;
+	bdi: HTMLAttributes;
+	bdo: HTMLAttributes;
+	br: HTMLAttributes;
+	cite: HTMLAttributes;
+	code: HTMLAttributes;
+	data: DataAttributes;
+	dfn: HTMLAttributes;
+	em: HTMLAttributes;
+	i: HTMLAttributes;
+	kbd: HTMLAttributes;
+	mark: HTMLAttributes;
+	q: QuoteAttributes;
+	rp: HTMLAttributes;
+	rt: HTMLAttributes;
+	ruby: HTMLAttributes;
+	s: HTMLAttributes;
+	samp: HTMLAttributes;
+	small: HTMLAttributes;
+	span: HTMLAttributes;
+	strong: HTMLAttributes;
+	sub: HTMLAttributes;
+	sup: HTMLAttributes;
+	time: TimeAttributes;
+	u: HTMLAttributes;
+	var: HTMLAttributes;
+	wbr: HTMLAttributes;
+
+	// Image and Multimedia
+	img: ImgAttributes;
+	audio: AudioAttributes;
+	video: VideoAttributes;
+	source: SourceAttributes;
+	track: TrackAttributes;
+	picture: HTMLAttributes;
+	map: MapAttributes;
+	area: AreaAttributes;
+
+	// Embedded Content
+	iframe: IframeAttributes;
+	embed: EmbedAttributes;
+	object: ObjectAttributes;
+	param: HTMLAttributes;
+	portal: HTMLAttributes;
+
+	// Canvas / Graphics
+	canvas: CanvasAttributes;
+
+	// SVG and MathML
+	svg: SVGAttributes;
+	path: SVGPathAttributes;
+	circle: SVGCircleAttributes;
+	ellipse: SVGEllipseAttributes;
+	line: SVGLineAttributes;
+	polygon: SVGPolygonAttributes;
+	polyline: SVGPolylineAttributes;
+	rect: SVGRectAttributes;
+	g: SVGAttributes;
+	defs: SVGAttributes;
+	symbol: SVGAttributes;
+	use: SVGUseAttributes;
+	text: SVGTextAttributes;
+	tspan: SVGTextAttributes;
+	image: SVGAttributes;
+	clipPath: SVGAttributes;
+	mask: SVGAttributes;
+	pattern: SVGAttributes;
+	linearGradient: SVGAttributes;
+	radialGradient: SVGAttributes;
+	stop: SVGAttributes;
+	filter: SVGAttributes;
+	feBlend: SVGAttributes;
+	feColorMatrix: SVGAttributes;
+	feComponentTransfer: SVGAttributes;
+	feComposite: SVGAttributes;
+	feConvolveMatrix: SVGAttributes;
+	feDiffuseLighting: SVGAttributes;
+	feDisplacementMap: SVGAttributes;
+	feDropShadow: SVGAttributes;
+	feFlood: SVGAttributes;
+	feFuncA: SVGAttributes;
+	feFuncB: SVGAttributes;
+	feFuncG: SVGAttributes;
+	feFuncR: SVGAttributes;
+	feGaussianBlur: SVGAttributes;
+	feImage: SVGAttributes;
+	feMerge: SVGAttributes;
+	feMergeNode: SVGAttributes;
+	feMorphology: SVGAttributes;
+	feOffset: SVGAttributes;
+	fePointLight: SVGAttributes;
+	feSpecularLighting: SVGAttributes;
+	feSpotLight: SVGAttributes;
+	feTile: SVGAttributes;
+	feTurbulence: SVGAttributes;
+	foreignObject: SVGAttributes;
+	marker: SVGAttributes;
+	metadata: SVGAttributes;
+	view: SVGAttributes;
+	desc: SVGAttributes;
+	switch: SVGAttributes;
+	animate: SVGAttributes;
+	animateMotion: SVGAttributes;
+	animateTransform: SVGAttributes;
+	set: SVGAttributes;
+	mpath: SVGAttributes;
+
+	// MathML (basic support)
+	math: HTMLAttributes;
+	mi: HTMLAttributes;
+	mo: HTMLAttributes;
+	mn: HTMLAttributes;
+	ms: HTMLAttributes;
+	mtext: HTMLAttributes;
+	mspace: HTMLAttributes;
+	mfrac: HTMLAttributes;
+	mrow: HTMLAttributes;
+	msqrt: HTMLAttributes;
+	mroot: HTMLAttributes;
+	msub: HTMLAttributes;
+	msup: HTMLAttributes;
+	msubsup: HTMLAttributes;
+	mover: HTMLAttributes;
+	munder: HTMLAttributes;
+	munderover: HTMLAttributes;
+	mmultiscripts: HTMLAttributes;
+	mtable: HTMLAttributes;
+	mtr: HTMLAttributes;
+	mtd: HTMLAttributes;
+
+	// Scripting
+	script: ScriptAttributes;
+	noscript: HTMLAttributes;
+
+	// Demarcating Edits
+	del: DelAttributes;
+	ins: InsAttributes;
+
+	// Table Content
+	table: TableAttributes;
+	caption: HTMLAttributes;
+	colgroup: ColgroupAttributes;
+	col: ColAttributes;
+	thead: HTMLAttributes;
+	tbody: HTMLAttributes;
+	tfoot: HTMLAttributes;
+	tr: HTMLAttributes;
+	th: ThAttributes;
+	td: TdAttributes;
+
+	// Forms
+	form: FormAttributes;
+	label: LabelAttributes;
+	input: InputAttributes;
+	button: ButtonAttributes;
+	select: SelectAttributes;
+	datalist: HTMLAttributes;
+	optgroup: OptgroupAttributes;
+	option: OptionAttributes;
+	textarea: TextareaAttributes;
+	fieldset: FieldsetAttributes;
+	legend: HTMLAttributes;
+	meter: MeterAttributes;
+	output: OutputAttributes;
+	progress: ProgressAttributes;
+
+	// Interactive Elements
+	details: DetailsAttributes;
+	summary: HTMLAttributes;
+	dialog: DialogAttributes;
+
+	slot: SlotAttributes;
+	template: TemplateAttributes;
+	[key: string]: HTMLAttributes;
+}

--- a/packages/core/src/jsx/types/unions.ts
+++ b/packages/core/src/jsx/types/unions.ts
@@ -1,0 +1,196 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+// Input element type attribute
+export type InputType =
+	| 'text'
+	| 'password'
+	| 'email'
+	| 'number'
+	| 'tel'
+	| 'url'
+	| 'search'
+	| 'date'
+	| 'time'
+	| 'datetime-local'
+	| 'month'
+	| 'week'
+	| 'color'
+	| 'file'
+	| 'hidden'
+	| 'checkbox'
+	| 'radio'
+	| 'range'
+	| 'submit'
+	| 'reset'
+	| 'button'
+	| 'image';
+
+// Button element type attribute
+export type ButtonType = 'button' | 'submit' | 'reset';
+
+// Anchor target attribute (allows custom frame names via string & {})
+export type AnchorTarget =
+	| '_blank'
+	| '_self'
+	| '_parent'
+	| '_top'
+	| (string & {});
+
+// Form method attribute
+export type FormMethod = 'get' | 'post' | 'dialog';
+
+// Form enctype attribute
+export type FormEncType =
+	| 'application/x-www-form-urlencoded'
+	| 'multipart/form-data'
+	| 'text/plain';
+
+// Autocomplete attribute values
+export type AutoComplete =
+	| 'on'
+	| 'off'
+	| 'name'
+	| 'honorific-prefix'
+	| 'given-name'
+	| 'additional-name'
+	| 'family-name'
+	| 'honorific-suffix'
+	| 'nickname'
+	| 'email'
+	| 'username'
+	| 'new-password'
+	| 'current-password'
+	| 'one-time-code'
+	| 'organization-title'
+	| 'organization'
+	| 'street-address'
+	| 'address-line1'
+	| 'address-line2'
+	| 'address-line3'
+	| 'address-level4'
+	| 'address-level3'
+	| 'address-level2'
+	| 'address-level1'
+	| 'country'
+	| 'country-name'
+	| 'postal-code'
+	| 'cc-name'
+	| 'cc-given-name'
+	| 'cc-additional-name'
+	| 'cc-family-name'
+	| 'cc-number'
+	| 'cc-exp'
+	| 'cc-exp-month'
+	| 'cc-exp-year'
+	| 'cc-csc'
+	| 'cc-type'
+	| 'transaction-currency'
+	| 'transaction-amount'
+	| 'language'
+	| 'bday'
+	| 'bday-day'
+	| 'bday-month'
+	| 'bday-year'
+	| 'sex'
+	| 'tel'
+	| 'tel-country-code'
+	| 'tel-national'
+	| 'tel-area-code'
+	| 'tel-local'
+	| 'tel-extension'
+	| 'impp'
+	| 'url'
+	| 'photo'
+	| (string & {});
+
+// Loading attribute for lazy loading
+export type LoadingBehavior = 'eager' | 'lazy';
+
+// Decoding attribute for images
+export type DecodingBehavior = 'sync' | 'async' | 'auto';
+
+// Preload attribute for media
+export type PreloadBehavior = 'none' | 'metadata' | 'auto' | '';
+
+// Cross-origin attribute
+export type CrossOrigin = 'anonymous' | 'use-credentials' | '';
+
+// Text direction
+export type TextDirection = 'ltr' | 'rtl' | 'auto';
+
+// Content editable
+export type ContentEditable = boolean | 'true' | 'false' | 'inherit';
+
+// Input mode for virtual keyboards
+export type InputMode =
+	| 'none'
+	| 'text'
+	| 'decimal'
+	| 'numeric'
+	| 'tel'
+	| 'search'
+	| 'email'
+	| 'url';
+
+// Enter key hint for virtual keyboards
+export type EnterKeyHint =
+	| 'enter'
+	| 'done'
+	| 'go'
+	| 'next'
+	| 'previous'
+	| 'search'
+	| 'send';
+
+// Wrap attribute for textarea
+export type TextWrap = 'soft' | 'hard' | 'off';
+
+// Table scope attribute
+export type TableScope = 'col' | 'colgroup' | 'row' | 'rowgroup';
+
+// Referrer policy
+export type ReferrerPolicy =
+	| ''
+	| 'no-referrer'
+	| 'no-referrer-when-downgrade'
+	| 'origin'
+	| 'origin-when-cross-origin'
+	| 'same-origin'
+	| 'strict-origin'
+	| 'strict-origin-when-cross-origin'
+	| 'unsafe-url';
+
+// Autocapitalize
+export type AutoCapitalize =
+	| 'off'
+	| 'none'
+	| 'on'
+	| 'sentences'
+	| 'words'
+	| 'characters';
+
+// Popover API
+export type PopoverType = '' | 'auto' | 'manual';
+export type PopoverTargetAction = 'show' | 'hide' | 'toggle';


### PR DESCRIPTION
This PR refactors our JSX type system to improve maintainability and developer experience.

Previously, all JSX definitions lived in a single `runtime.ts` file with many loose string types. I've moved these into a dedicated jsx/types/ directory and enforced strict string unions for attributes like aria-*, inputMode, and referrerPolicy. This ensures better autocomplete and compile-time safety.

I also addressed the build regression in `@effuse/ink` by ensuring `IntrinsicElements` is properly exported as an interface
