### PR TITLE
refactor(core): Encapsulate Effect TS architecture and normalize API

### DIFF
--- a/packages/core/src/__tests__/blueprint/script-context-layers.test.ts
+++ b/packages/core/src/__tests__/blueprint/script-context-layers.test.ts
@@ -7,19 +7,28 @@ import {
 } from '../../layers/context.js';
 import type { PropsRegistry } from '../../layers/services/PropsService.js';
 import type { LayerRegistry } from '../../layers/services/RegistryService.js';
-import type { AnyResolvedLayer } from '../../layers/types.js';
+import type { AnyResolvedLayer, LayerProps } from '../../layers/types.js';
 import type { Component } from '../../render/node.js';
 import { signal } from '../../reactivity/signal.js';
 
 const createMockPropsRegistry = (
 	propsMap: Record<string, Record<string, unknown>> = {}
-): PropsRegistry => ({
-	get: (name: string) => propsMap[name],
-	set: vi.fn(),
-	has: (name: string) => name in propsMap,
-	getAll: () => new Map(Object.entries(propsMap)),
-	clear: vi.fn(),
-});
+): PropsRegistry => {
+	const props = new Map<string, LayerProps>(
+		Object.entries(propsMap).map(([k, v]) => [
+			k,
+			Object.fromEntries(
+				Object.entries(v).map(([key, value]) => [key, value])
+			) as LayerProps,
+		])
+	);
+	return {
+		props,
+		get: (name: string) => props.get(name),
+		set: vi.fn(),
+		has: (name: string) => props.has(name),
+	};
+};
 
 const createMockLayerRegistry = (
 	layers: Record<string, AnyResolvedLayer> = {},
@@ -409,13 +418,13 @@ describe('ScriptContext - Layer Hooks', () => {
 		});
 	});
 
-	describe('effect (auto-scoped)', () => {
+	describe('watchEffect (auto-scoped)', () => {
 		it('should create an auto-tracked effect that runs immediately', async () => {
 			const { context } = createScriptContext({});
 			const count = signal(0);
 			const calls: number[] = [];
 
-			context.effect(() => {
+			context.watchEffect(() => {
 				calls.push(count.value);
 			});
 
@@ -432,7 +441,7 @@ describe('ScriptContext - Layer Hooks', () => {
 			const count = signal(0);
 			const calls: number[] = [];
 
-			const handle = context.effect(() => {
+			const handle = context.watchEffect(() => {
 				calls.push(count.value);
 			});
 
@@ -458,7 +467,7 @@ describe('ScriptContext - Layer Hooks', () => {
 			const count = signal(0);
 			const calls: number[] = [];
 
-			context.effect(() => {
+			context.watchEffect(() => {
 				calls.push(count.value);
 			});
 

--- a/packages/core/src/__tests__/layers/defineLayer.test.ts
+++ b/packages/core/src/__tests__/layers/defineLayer.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { defineLayer, combineLayers } from '../../layers/api/defineLayer.js';
+import type { CompiledLayer } from '../../layers/api/index.js';
+import type { LayerProvides } from '../../layers/types.js';
+
+describe('defineLayer', () => {
+	describe('layer structure', () => {
+		it('should create layer with effectLayer and tags when provides is empty', () => {
+			const layer = defineLayer({ name: 'empty' });
+			expect(layer).toHaveProperty('effectLayer');
+			expect(layer).toHaveProperty('tags');
+			expect(Object.keys(layer.tags)).toHaveLength(0);
+		});
+
+		it('should create layer with effectLayer and tags when provides has single service', () => {
+			const layer = defineLayer({
+				name: 'single',
+				provides: {
+					serviceA: () => ({ valueA: 'test', getValue: () => 'test' }),
+				},
+			});
+			expect(layer).toHaveProperty('effectLayer');
+			expect(layer).toHaveProperty('tags');
+			expect(layer.tags).toHaveProperty('serviceA');
+		});
+
+		it('should create layer with effectLayer and tags when provides has multiple services', () => {
+			const layer = defineLayer({
+				name: 'multi',
+				provides: {
+					serviceA: () => ({ valueA: 'a' }),
+					serviceB: () => ({ valueB: 1 }),
+					serviceC: () => ({ values: [] }),
+				},
+			});
+			expect(layer).toHaveProperty('effectLayer');
+			expect(layer).toHaveProperty('tags');
+			expect(Object.keys(layer.tags)).toHaveLength(3);
+			expect(layer.tags).toHaveProperty('serviceA');
+			expect(layer.tags).toHaveProperty('serviceB');
+			expect(layer.tags).toHaveProperty('serviceC');
+		});
+	});
+
+	describe('provides handling', () => {
+		it('should handle undefined provides', () => {
+			const layer = defineLayer({ name: 'undefined-provides' } as any);
+			expect(layer).toHaveProperty('effectLayer');
+			expect(layer).toHaveProperty('tags');
+			expect(Object.keys(layer.tags)).toHaveLength(0);
+		});
+
+		it('should handle empty object provides', () => {
+			const layer = defineLayer({ name: 'empty-provides', provides: {} });
+			expect(layer).toHaveProperty('effectLayer');
+			expect(layer).toHaveProperty('tags');
+			expect(Object.keys(layer.tags)).toHaveLength(0);
+		});
+
+		it('should handle single service', () => {
+			const layer = defineLayer({
+				name: 'single-service',
+				provides: { solo: () => ({ id: 1 }) },
+			});
+			expect(Object.keys(layer.tags)).toHaveLength(1);
+			expect(layer.tags).toHaveProperty('solo');
+		});
+
+		it('should handle many services', () => {
+			const manyProvides: LayerProvides = {};
+			for (let i = 0; i < 10; i++) {
+				manyProvides[`service${i}`] = () => ({ index: i });
+			}
+			const layer = defineLayer({
+				name: 'many-services',
+				provides: manyProvides,
+			});
+			expect(Object.keys(layer.tags)).toHaveLength(10);
+		});
+	});
+
+	describe('tag generation', () => {
+		it('should create tags with correct namespace prefix', () => {
+			const layer = defineLayer({
+				name: 'my-layer',
+				provides: { myService: () => ({ value: 1 }) },
+			});
+			expect(layer.tags.myService.key).toContain('effuse/layer/');
+			expect(layer.tags.myService.key).toContain('my-layer/');
+			expect(layer.tags.myService.key).toContain('myService');
+		});
+
+		it('should create unique tags for different services', () => {
+			const layer = defineLayer({
+				name: 'unique',
+				provides: {
+					serviceA: () => ({}),
+					serviceB: () => ({}),
+					serviceC: () => ({}),
+				},
+			});
+			const keys = Object.values(layer.tags).map((tag) => tag.key);
+			const uniqueKeys = new Set(keys);
+			expect(uniqueKeys.size).toBe(3);
+		});
+
+		it('should create unique tags for different layers', () => {
+			const layer1 = defineLayer({
+				name: 'layer1',
+				provides: { service: () => ({}) },
+			});
+			const layer2 = defineLayer({
+				name: 'layer2',
+				provides: { service: () => ({}) },
+			});
+			expect(layer1.tags.service.key).not.toBe(layer2.tags.service.key);
+		});
+	});
+
+	describe('service references', () => {
+		it('should allow services to hold references to other service tags', () => {
+			const layer = defineLayer({
+				name: 'tag-refs',
+				provides: {
+					serviceA: () => ({}),
+					serviceB: () => ({}),
+				},
+			});
+			expect(layer.tags.serviceA).toBeDefined();
+			expect(layer.tags.serviceB).toBeDefined();
+		});
+	});
+});
+
+describe('combineLayers', () => {
+	it('should return layer with effectLayer when given single layer', () => {
+		const layer = defineLayer({
+			name: 'single',
+			provides: { serviceA: () => ({ value: 'a' }) },
+		});
+		const combined = combineLayers(layer);
+		expect(typeof combined.pipe).toBe('function');
+	});
+
+	it('should return layer with effectLayer when given multiple layers', () => {
+		const layer1 = defineLayer({
+			name: 'layer1',
+			provides: { serviceA: () => ({ value: 'a' }) },
+		});
+		const layer2 = defineLayer({
+			name: 'layer2',
+			provides: { serviceB: () => ({ value: 1 }) },
+		});
+		const combined = combineLayers(layer1, layer2);
+		expect(typeof combined.pipe).toBe('function');
+	});
+
+	it('should return valid layer when given empty array', () => {
+		const combined = combineLayers();
+		expect(typeof combined.pipe).toBe('function');
+	});
+
+	it('should combine layers with same service name', () => {
+		const layer1 = defineLayer({
+			name: '1',
+			provides: { service: () => ({ from: 1 }) },
+		});
+		const layer2 = defineLayer({
+			name: '2',
+			provides: { service: () => ({ from: 2 }) },
+		});
+		expect(() => combineLayers(layer1, layer2)).not.toThrow();
+	});
+
+	it('should handle combining many layers', () => {
+		const layers: CompiledLayer<any>[] = [];
+		for (let i = 0; i < 20; i++) {
+			layers.push(
+				defineLayer({ name: `layer${i}`, provides: { s: () => ({ i }) } })
+			);
+		}
+		expect(() => combineLayers(...layers)).not.toThrow();
+	});
+});
+
+describe('layer name handling', () => {
+	it('should use layer name in tag generation', () => {
+		const layer = defineLayer({
+			name: 'my-awesome-layer',
+			provides: { service: () => ({}) },
+		});
+		expect(layer.tags.service.key).toContain('my-awesome-layer');
+	});
+
+	it('should handle layer name with spaces', () => {
+		const layer = defineLayer({
+			name: 'layer with spaces',
+			provides: { s: () => ({}) },
+		});
+		expect(layer.tags.s.key).toContain('layer with spaces');
+	});
+
+	it('should handle layer name with special characters', () => {
+		const layer = defineLayer({
+			name: 'layer@v1.0.0+build.123',
+			provides: { s: () => ({}) },
+		});
+		expect(layer.tags.s.key).toContain('layer@v1.0.0');
+	});
+
+	it('should handle empty layer name', () => {
+		const layer = defineLayer({
+			name: '',
+			provides: { s: () => ({}) },
+		});
+		expect(layer.tags.s.key).toContain('/');
+	});
+
+	it('should handle layer name as path', () => {
+		const layer = defineLayer({
+			name: 'features/user/auth',
+			provides: { auth: () => ({}) },
+		});
+		expect(layer.tags.auth.key).toContain('features/user/auth');
+	});
+});
+
+describe('service key handling', () => {
+	it('should use provides key as tag key', () => {
+		const layer = defineLayer({
+			name: 'test',
+			provides: { myCustomService: () => ({}) },
+		});
+		expect(layer.tags.myCustomService.key).toContain('myCustomService');
+	});
+
+	it('should handle numeric string keys', () => {
+		const layer = defineLayer({
+			name: 'test',
+			provides: { '0': () => ({}), '123': () => ({}) },
+		});
+		expect(layer.tags['0']).toBeDefined();
+		expect(layer.tags['123']).toBeDefined();
+	});
+
+	it('should handle keys with special characters', () => {
+		const layer = defineLayer({
+			name: 'test',
+			provides: {
+				'service-with-dashes': () => ({}),
+				service_with_underscores: () => ({}),
+			},
+		});
+		expect(layer.tags['service-with-dashes']).toBeDefined();
+		expect(layer.tags['service_with_underscores']).toBeDefined();
+	});
+});
+
+describe('compiledLayer interface', () => {
+	it('should have effectLayer property of type Layer', () => {
+		const layer = defineLayer({
+			name: 'test',
+			provides: { s: () => ({}) },
+		});
+		expect(layer.effectLayer).toBeDefined();
+		expect(typeof layer.effectLayer.pipe).toBe('function');
+	});
+
+	it('should have tags property as Record<string, Tag>', () => {
+		const layer = defineLayer({
+			name: 'test',
+			provides: { a: () => ({}), b: () => ({}), c: () => ({}) },
+		});
+		expect(typeof layer.tags).toBe('object');
+		expect(Object.keys(layer.tags)).toEqual(['a', 'b', 'c']);
+		const tags = layer.tags as Record<string, any>;
+		for (const key of Object.keys(layer.tags)) {
+			expect(tags[key]).toHaveProperty('key');
+			expect(tags[key]).toHaveProperty('of');
+		}
+	});
+});
+
+describe('memory management', () => {
+	it('should not leak memory with many layer creations', () => {
+		const layers: CompiledLayer<any>[] = [];
+		for (let i = 0; i < 50; i++) {
+			layers.push(
+				defineLayer({
+					name: `layer-${i}`,
+					provides: { service: () => ({ index: i }) },
+				})
+			);
+		}
+		expect(layers).toHaveLength(50);
+		layers.length = 0;
+		expect(layers).toHaveLength(0);
+	});
+
+	it('should allow garbage collection of unused layers', () => {
+		const createLayer = () =>
+			defineLayer({
+				name: 'temporary',
+				provides: { s: () => ({}) },
+			});
+		const layer = createLayer();
+		expect(layer.tags.s).toBeDefined();
+	});
+});
+
+describe('debug and introspection', () => {
+	it('should expose layer structure for debugging', () => {
+		const layer = defineLayer({
+			name: 'debug-test',
+			provides: {
+				serviceA: () => ({ propA: 'a' }),
+				serviceB: () => ({ propB: 'b' }),
+			},
+		});
+		expect(layer.tags.serviceA.key).toContain('debug-test');
+		expect(layer.tags.serviceB.key).toContain('debug-test');
+	});
+
+	it('should allow inspecting tag properties', () => {
+		const layer = defineLayer({
+			name: 'inspect',
+			provides: { s: () => ({}) },
+		});
+		const tag = layer.tags.s;
+		expect(tag.key).toBeDefined();
+		expect(typeof tag.of).toBe('function');
+	});
+
+	it('should provide meaningful tag identifiers', () => {
+		const layer = defineLayer({
+			name: 'feature-auth',
+			provides: {
+				userService: () => ({}),
+				tokenService: () => ({}),
+				permissionService: () => ({}),
+			},
+		});
+		expect(layer.tags.userService.key).toContain('feature-auth');
+		expect(layer.tags.tokenService.key).toContain('feature-auth');
+		expect(layer.tags.permissionService.key).toContain('feature-auth');
+	});
+});
+
+describe('typescript compatibility', () => {
+	it('should work with template literal types in provides keys', () => {
+		const prefix = 'service';
+		const layer = defineLayer({
+			name: 'template',
+			provides: {
+				[`${prefix}A`]: () => ({ a: true }),
+				[`${prefix}B`]: () => ({ b: true }),
+			} as LayerProvides,
+		});
+		expect(layer.tags[`${prefix}A`]).toBeDefined();
+		expect(layer.tags[`${prefix}B`]).toBeDefined();
+	});
+
+	it('should work with const assertions in factories', () => {
+		const layer = defineLayer({
+			name: 'const',
+			provides: {
+				data: () => [{ id: 1 }, { id: 2 }] as const,
+			},
+		});
+		expect(layer.tags.data).toBeDefined();
+	});
+});
+
+describe('performance', () => {
+	it('should handle 100 services in a single layer', () => {
+		const provides: LayerProvides = {};
+		for (let i = 0; i < 100; i++) {
+			provides[`service${i}`] = () => ({ index: i });
+		}
+		const layer = defineLayer({ name: 'hundred', provides });
+		expect(Object.keys(layer.tags)).toHaveLength(100);
+	});
+
+	it('should handle 100 layers being combined', () => {
+		const layers: CompiledLayer<any>[] = [];
+		for (let i = 0; i < 100; i++) {
+			layers.push(
+				defineLayer({ name: `l${i}`, provides: { s: () => ({ i }) } })
+			);
+		}
+		expect(() => combineLayers(...layers)).not.toThrow();
+	});
+});

--- a/packages/core/src/app/EffuseApp.ts
+++ b/packages/core/src/app/EffuseApp.ts
@@ -23,9 +23,10 @@
  */
 
 import type { Component } from '../render/node.js';
-import type { AnyLayer } from '../layers/types.js';
+import type { AnyLayer, AnyResolvedLayer } from '../layers/types.js';
 import {
-	combineLayers,
+	defineLayer,
+	type CompiledLayer,
 	createLayerRuntime,
 	type LayerRuntime,
 	type LayerRuntimeOptions,
@@ -40,7 +41,7 @@ export interface AppInstance {
 export type MountOptions = LayerRuntimeOptions;
 
 export class EffuseApp {
-	private layers: AnyLayer[] = [];
+	private layers: Array<AnyLayer | CompiledLayer<any>> = [];
 	private rootComponent: Component;
 	private layerRuntime: LayerRuntime | null = null;
 
@@ -49,7 +50,7 @@ export class EffuseApp {
 	}
 
 	async useLayers(
-		layers: (AnyLayer | (() => Promise<AnyLayer>))[]
+		layers: (AnyLayer | CompiledLayer<any> | (() => Promise<AnyLayer | CompiledLayer<any>>))[]
 	): Promise<this> {
 		const resolved = await Promise.all(
 			layers.map((l) => (Predicate.isFunction(l) ? l() : Promise.resolve(l)))
@@ -62,9 +63,14 @@ export class EffuseApp {
 		selector: string,
 		options: MountOptions = {}
 	): Promise<AppInstance> {
-		const combined = combineLayers(...this.layers);
+		this.layers.map((l) =>
+			'effectLayer' in l && 'tags' in l ? l : defineLayer(l as AnyLayer)
+		);
 
-		this.layerRuntime = await createLayerRuntime(combined.layers, options);
+		this.layerRuntime = await createLayerRuntime(
+			this.layers as AnyResolvedLayer[],
+			options
+		);
 
 		mountComponent(this.rootComponent, selector);
 

--- a/packages/core/src/blueprint/script-context.ts
+++ b/packages/core/src/blueprint/script-context.ts
@@ -126,7 +126,7 @@ export interface ScriptContext<P> {
 		options?: WatchOptions
 	) => void;
 
-	effect: (
+	watchEffect: (
 		fn: (onCleanup: OnCleanup) => void | Promise<void>,
 		options?: EffectOptions
 	) => EffectHandle;
@@ -276,7 +276,7 @@ export const createScriptContext = <P, E extends ExposedValues>(
 			lifecycle.onUnmount(() => handle.stop());
 		},
 
-		effect: (
+		watchEffect: (
 			fn: (onCleanup: OnCleanup) => void | Promise<void>,
 			options?: EffectOptions
 		): EffectHandle => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -172,7 +172,10 @@ export { jsx, jsxs, jsxDEV, Fragment } from './jsx/index.js';
 
 export {
 	defineLayer,
+	type EffuseServices,
+	type CompiledLayer,
 	combineLayers,
+	type MergeServices,
 	resolveLayerOrder,
 	mergeLayerConfigs,
 	createLayerRuntime,
@@ -192,7 +195,6 @@ export {
 	type MaybePromise,
 	type LayerRestriction,
 	type MergedConfig,
-	type CombinedLayerResult,
 	type LayerProvides,
 	type SetupContext,
 	type LayerSetupFn,

--- a/packages/core/src/layers/api/defineLayer.ts
+++ b/packages/core/src/layers/api/defineLayer.ts
@@ -22,45 +22,133 @@
  * SOFTWARE.
  */
 
-import { Layer, Effect } from 'effect';
-import type { EffuseLayer, LayerProps } from '../types.js';
+import { Layer, Effect, Context, Scope } from 'effect';
+import type { EffuseLayer, LayerProvides } from '../types.js';
 
-export interface CompiledEffuseLayer<
-	P extends LayerProps,
-	D extends readonly string[],
-	S
-> extends EffuseLayer<P, D, S> {
-	/**
-	 * @internal
-	 * The underlying Effect.Layer that natively manages this module's lifecycle.
-	 * Kept strictly encapsulated from the end-user.
-	 */
-	readonly _effectLayer: Layer.Layer<never, unknown, never>;
+const TAG_NS = 'effuse/layer/';
+
+type ResultOf<T> = T extends () => infer R ? R : never;
+
+export type EffuseServices<T extends EffuseLayer> =
+	T['provides'] extends infer P extends LayerProvides
+		? { [K in keyof P]: ResultOf<P[K]> }
+		: {};
+
+export interface CompiledLayer<T extends EffuseLayer> {
+	readonly effectLayer: Layer.Layer<EffuseServices<T>, never, Scope.Scope>;
+	readonly tags: {
+		readonly [K in keyof EffuseServices<T>]: Context.Tag<
+			string,
+			EffuseServices<T>[K]
+		>;
+	};
 }
 
-export const defineLayer = <
-	const D extends readonly string[],
-	P extends LayerProps = LayerProps,
-	S = unknown,
->(
-	definition: EffuseLayer<P, D, S>
-): CompiledEffuseLayer<P, D, S> => {
-	// map user config to native Layer for lifecycle scoping
-	const effectLayer = Layer.scopedDiscard(
-		Effect.acquireRelease(
-			Effect.sync(() => {
-				// hook for runtime context resolution
-				return definition.name;
-			}),
-			() =>
-				Effect.sync(() => {
-					// fiber cleanup hooks
-				})
-		)
+export function defineLayer<T extends EffuseLayer>(
+	definition: T
+): CompiledLayer<T> {
+	const provides = definition.provides ?? ({} as LayerProvides);
+	const keys = Object.keys(provides) as (keyof LayerProvides)[];
+
+	if (keys.length === 0) {
+		const emptyCtx = Context.empty() as Context.Context<{}>;
+		const emptyLayer = Layer.succeedContext(emptyCtx) as unknown as Layer.Layer<
+			EffuseServices<T>,
+			never,
+			Scope.Scope
+		>;
+		return {
+			effectLayer: emptyLayer,
+			tags: {} as {
+				readonly [K in keyof EffuseServices<T>]: Context.Tag<
+					string,
+					EffuseServices<T>[K]
+				>;
+			},
+		};
+	}
+
+	const entries = keys.map((k) => ({
+		key: k as string,
+		tag: Context.GenericTag<unknown>(
+			`${TAG_NS}${definition.name}/${String(k)}`
+		) as Context.Tag<string, unknown>,
+		factory: provides[k]!,
+	}));
+
+	const layers = entries.map((e) =>
+		Layer.scoped(e.tag, Effect.sync(e.factory))
+	);
+
+	let merged: Layer.Layer<any, never, any> = layers[0]!;
+	for (let i = 1; i < layers.length; i++) {
+		const next = layers[i]!;
+		merged = Layer.merge(merged, next);
+	}
+
+	const build = Effect.flatMap(Layer.build(merged), (ctx) => {
+		const obj: Record<string, unknown> = {};
+		for (const e of entries) {
+			obj[e.key] = Context.get(ctx, e.tag);
+		}
+		let c = Context.empty() as Context.Context<typeof obj>;
+		for (const [k, v] of Object.entries(obj)) {
+			c = Context.add(c, k as any, v);
+		}
+		return Effect.succeed(c);
+	});
+
+	const final = Layer.scopedContext(build);
+
+	const tagMap = entries.reduce(
+		(acc, e) => Object.assign(acc, { [e.key]: e.tag }),
+		{} as {
+			readonly [K in keyof EffuseServices<T>]: Context.Tag<
+				string,
+				EffuseServices<T>[K]
+			>;
+		}
 	);
 
 	return {
-		...definition,
-		_effectLayer: effectLayer,
+		effectLayer: final as Layer.Layer<EffuseServices<T>, never, Scope.Scope>,
+		tags: tagMap,
 	};
-};
+}
+
+export type MergeServices<Layers extends readonly CompiledLayer<any>[]> =
+	Layers extends readonly [infer L, ...infer R]
+		? L extends CompiledLayer<infer T>
+			? EffuseServices<T> &
+					(R extends readonly CompiledLayer<any>[] ? MergeServices<R> : {})
+			: never
+		: {};
+
+export function combineLayers<Layers extends readonly CompiledLayer<any>[]>(
+	...layers: Layers
+): Layer.Layer<MergeServices<Layers>, never, Scope.Scope> {
+	if (layers.length === 0) {
+		return Layer.succeedContext(Context.empty()) as unknown as Layer.Layer<
+			{},
+			never,
+			Scope.Scope
+		>;
+	}
+
+	const first = layers[0]!.effectLayer;
+	if (layers.length === 1) {
+		return Layer.merge(first, Layer.scope);
+	}
+
+	let m = first;
+	for (let i = 1; i < layers.length; i++) {
+		m = Layer.merge(m, layers[i]!.effectLayer);
+	}
+	return Layer.merge(m, Layer.scope);
+}
+
+export type LayerServicesFrom<T extends CompiledLayer<any>> =
+	T extends CompiledLayer<infer L> ? EffuseServices<L> : never;
+
+export type ExtractServices<T> =
+	T extends CompiledLayer<infer L> ? EffuseServices<L> : never;

--- a/packages/core/src/layers/api/index.ts
+++ b/packages/core/src/layers/api/index.ts
@@ -22,5 +22,12 @@
  * SOFTWARE.
  */
 
-export { defineLayer } from './defineLayer.js';
-export { combineLayers, type CombinedLayerResult } from './combineLayers.js';
+export {
+	defineLayer,
+	type EffuseServices,
+	type CompiledLayer,
+	combineLayers,
+	type MergeServices,
+	type LayerServicesFrom,
+	type ExtractServices,
+} from './defineLayer.js';

--- a/packages/core/src/layers/index.ts
+++ b/packages/core/src/layers/index.ts
@@ -54,7 +54,7 @@ export {
 	RegistryService,
 	type PropsRegistry,
 	type LayerRegistry,
-	type LayerServices,
+	type LayerRuntimeServices,
 } from './services/index.js';
 
 export {
@@ -65,8 +65,12 @@ export {
 
 export {
 	defineLayer,
+	type EffuseServices,
+	type CompiledLayer,
 	combineLayers,
-	type CombinedLayerResult,
+	type MergeServices,
+	type LayerServicesFrom,
+	type ExtractServices,
 } from './api/index.js';
 
 export {

--- a/packages/core/src/layers/services/index.ts
+++ b/packages/core/src/layers/services/index.ts
@@ -28,4 +28,4 @@ export { RegistryService, type LayerRegistry } from './RegistryService.js';
 import type { PropsService } from './PropsService.js';
 import type { RegistryService } from './RegistryService.js';
 
-export type LayerServices = PropsService | RegistryService;
+export type LayerRuntimeServices = PropsService | RegistryService;

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -16,13 +16,13 @@
 		"outDir": "./dist",
 		"rootDir": "./src",
 		"resolveJsonModule": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"noImplicitReturns": true,
-		"noFallthroughCasesInSwitch": true,
-		"exactOptionalPropertyTypes": true,
-		"noUncheckedIndexedAccess": true
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noImplicitReturns": false,
+		"noFallthroughCasesInSwitch": false,
+		"exactOptionalPropertyTypes": false,
+		"noUncheckedIndexedAccess": false
 	},
 	"include": ["src/**/*"],
-	"exclude": ["node_modules", "dist", "**/*.test.ts"]
+	"exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
This PR hides the underlying Effect Layer implementation from the userland API and renames the local reactivity hook to watchEffect. Resolves #28