### PR TITLE
fix(#40): wire hook onMount to active component lifecycle, remove Effect from public lifecycle API

### DIFF
--- a/packages/core/src/__tests__/blueprint/script-context-layers.test.ts
+++ b/packages/core/src/__tests__/blueprint/script-context-layers.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { Effect } from 'effect';
 import { createScriptContext } from '../../blueprint/script-context.js';
 import {
 	initGlobalLayerContext,
@@ -474,7 +473,7 @@ describe('ScriptContext - Layer Hooks', () => {
 			await new Promise((r) => setTimeout(r, 10));
 			expect(calls).toContain(0);
 
-			Effect.runSync(state.lifecycle.runCleanup());
+			state.lifecycle.runCleanup();
 			const callsAfterUnmount = calls.length;
 
 			count.value = 99;
@@ -552,7 +551,7 @@ describe('ScriptContext - Layer Hooks', () => {
 			await new Promise((r) => setTimeout(r, 10));
 			expect(calls.length).toBeGreaterThanOrEqual(1);
 
-			Effect.runSync(state.lifecycle.runCleanup());
+			state.lifecycle.runCleanup();
 			const callsAfterUnmount = calls.length;
 
 			a.value = 99;
@@ -661,7 +660,7 @@ describe('ScriptContext - Layer Hooks', () => {
 			await new Promise((r) => setTimeout(r, 10));
 			expect(calls).toContain(0);
 
-			Effect.runSync(state.lifecycle.runCleanup());
+			state.lifecycle.runCleanup();
 			const callsAfterUnmount = calls.length;
 
 			count.value = 42;

--- a/packages/core/src/blueprint/define.ts
+++ b/packages/core/src/blueprint/define.ts
@@ -35,6 +35,7 @@ import type { ComponentLifecycle } from './lifecycle.js';
 import type { EffuseLayerRegistry, LayerPropsOf } from '../layers/types.js';
 import type { LayerContext } from '../layers/context.js';
 import { getLayerContext, isLayerRuntimeReady } from '../layers/context.js';
+import { withActiveLifecycle } from './lifecycle.js';
 import { LayerRuntimeNotReadyError } from '../layers/errors.js';
 
 interface PropsWithChildren {
@@ -151,16 +152,20 @@ export function define<
 						layer: layerContext,
 					};
 
-					scriptResult = (
-						options as unknown as DefineOptionsWithLayer<P, E, K>
-					).script(extendedContext);
+					scriptResult = withActiveLifecycle(state.lifecycle, () =>
+						(
+							options as unknown as DefineOptionsWithLayer<P, E, K>
+						).script(extendedContext)
+					);
 				} else {
 					throw new LayerRuntimeNotReadyError({
 						layerName: layerName,
 					});
 				}
 			} else {
-				scriptResult = (options as DefineOptions<P, E>).script(context);
+				scriptResult = withActiveLifecycle(state.lifecycle, () =>
+					(options as DefineOptions<P, E>).script(context)
+				);
 			}
 
 			if (Predicate.isNotNullable(scriptResult)) {

--- a/packages/core/src/blueprint/lifecycle.ts
+++ b/packages/core/src/blueprint/lifecycle.ts
@@ -25,13 +25,12 @@
 import { Effect, Exit, Predicate, Scope } from 'effect';
 
 export interface ComponentLifecycle {
-	readonly scope: Scope.CloseableScope;
 	readonly onMount: (fn: () => (() => void) | undefined) => void;
 	readonly onUnmount: (fn: () => void) => void;
 	readonly onBeforeMount: (fn: () => void) => void;
 	readonly onBeforeUnmount: (fn: () => void) => void;
 	readonly runMount: () => void;
-	readonly runCleanup: () => Effect.Effect<void>;
+	readonly runCleanup: () => void;
 }
 
 interface LifecycleState {
@@ -45,7 +44,7 @@ interface LifecycleState {
 const createLifecycleFns = (
 	scope: Scope.CloseableScope,
 	state: LifecycleState
-): Omit<ComponentLifecycle, 'scope'> => {
+): ComponentLifecycle => {
 	const onBeforeMount = (fn: () => void): void => {
 		if (!state.mounted) {
 			state.beforeMountCallbacks.push(fn);
@@ -84,21 +83,18 @@ const createLifecycleFns = (
 		state.mountCallbacks.length = 0;
 	};
 
-	const runCleanup = (): Effect.Effect<void> =>
-		Effect.gen(function* () {
-			for (const fn of state.beforeUnmountCallbacks) fn();
-			state.beforeUnmountCallbacks.length = 0;
+	const runCleanup = (): void => {
+		for (const fn of state.beforeUnmountCallbacks) fn();
+		state.beforeUnmountCallbacks.length = 0;
 
-			for (const cleanup of state.mountCleanups) {
-				if (Predicate.isFunction(cleanup)) {
-					cleanup();
-				}
-			}
-			state.mountCleanups.length = 0;
+		for (const cleanup of state.mountCleanups) {
+			if (Predicate.isFunction(cleanup)) cleanup();
+		}
+		state.mountCleanups.length = 0;
 
-			yield* Scope.close(scope, Exit.void);
-			state.mounted = false;
-		});
+		Effect.runSync(Scope.close(scope, Exit.void));
+		state.mounted = false;
+	};
 
 	return {
 		onMount,
@@ -121,5 +117,23 @@ const createState = (): LifecycleState => ({
 export const createComponentLifecycleSync = (): ComponentLifecycle => {
 	const scope = Effect.runSync(Scope.make());
 	const state = createState();
-	return { scope, ...createLifecycleFns(scope, state) };
+	return createLifecycleFns(scope, state);
+};
+
+let _activeLifecycle: ComponentLifecycle | null = null;
+
+export const getActiveLifecycle = (): ComponentLifecycle | null =>
+	_activeLifecycle;
+
+export const withActiveLifecycle = <T>(
+	lifecycle: ComponentLifecycle,
+	fn: () => T
+): T => {
+	const previous = _activeLifecycle;
+	_activeLifecycle = lifecycle;
+	try {
+		return fn();
+	} finally {
+		_activeLifecycle = previous;
+	}
 };

--- a/packages/core/src/blueprint/script-context.ts
+++ b/packages/core/src/blueprint/script-context.ts
@@ -22,8 +22,6 @@
  * SOFTWARE.
  */
 
-import { Effect, pipe } from 'effect';
-import type { Scope } from 'effect';
 import type {
 	Signal,
 	ReadonlySignal,
@@ -42,6 +40,7 @@ import {
 import { watchEffect as standaloneEffect } from '../effects/effect.js';
 import {
 	createComponentLifecycleSync,
+	withActiveLifecycle,
 	type ComponentLifecycle,
 } from './lifecycle.js';
 import { useCallback, useMemo } from './hooks.js';
@@ -64,7 +63,7 @@ import {
 	LayerRuntimeNotReadyError,
 	RouterNotConfiguredError,
 } from '../layers/errors.js';
-import { StoreGetterNotConfiguredError, mapEffuseErrors } from '../errors.js';
+import { StoreGetterNotConfiguredError } from '../errors.js';
 
 export type ExposedValues = object;
 
@@ -172,7 +171,6 @@ export interface ScriptContext<P> {
 export interface ScriptState<E extends ExposedValues> {
 	exposed: E;
 	lifecycle: ComponentLifecycle;
-	scope: Scope.CloseableScope | null;
 }
 
 let globalStoreGetter: ((name: string) => unknown) | null = null;
@@ -197,7 +195,6 @@ export const createScriptContext = <P, E extends ExposedValues>(
 	const state: ScriptState<E> = {
 		exposed: {} as E,
 		lifecycle,
-		scope: lifecycle.scope,
 	};
 
 	const getStore = storeGetter ?? globalStoreGetter;
@@ -362,7 +359,7 @@ export const runMountCallbacks = <E extends ExposedValues>(
 export const runUnmountCallbacks = <E extends ExposedValues>(
 	state: ScriptState<E>
 ): void => {
-	Effect.runSync(pipe(state.lifecycle.runCleanup(), mapEffuseErrors));
+	state.lifecycle.runCleanup();
 };
 
 export type { LayerContext };

--- a/packages/core/src/hooks/context.ts
+++ b/packages/core/src/hooks/context.ts
@@ -12,6 +12,7 @@ import {
 	traceHookCleanup,
 	traceHookDispose,
 } from '../layers/tracing/hooks.js';
+import { getActiveLifecycle } from '../blueprint/lifecycle.js';
 import { HookLayerNotReadyError } from './errors.js';
 import type {
 	HookContext,
@@ -51,10 +52,8 @@ export const createHookContext = <C>(
 ): {
 	ctx: HookContext<C>;
 	dispose: () => Promise<void>;
-	mountCallbacks: EffectCallback[];
 } => {
 	const cleanups: HookCleanup[] = [];
-	const mountCallbacks: EffectCallback[] = [];
 	const { scope } = createHookScope();
 	const name = hookName ?? 'anonymous';
 	let effectIndex = 0;
@@ -78,7 +77,10 @@ export const createHookContext = <C>(
 	};
 
 	const onMount = (fn: EffectCallback) => {
-		mountCallbacks.push(fn);
+		const lifecycle = getActiveLifecycle();
+		if (lifecycle) {
+			lifecycle.onMount(() => fn());
+		}
 	};
 
 	const layer = <K extends keyof EffuseLayerRegistry>(
@@ -144,5 +146,5 @@ export const createHookContext = <C>(
 		runAsync,
 	};
 
-	return { ctx, dispose, mountCallbacks };
+	return { ctx, dispose };
 };

--- a/packages/core/src/services/dom-renderer/mount.ts
+++ b/packages/core/src/services/dom-renderer/mount.ts
@@ -479,14 +479,13 @@ const mountNode = (
 			);
 
 			const stateWithLifecycle = context.state as unknown as {
-				lifecycle?: { runCleanup: () => Effect.Effect<void> };
+				lifecycle?: { runCleanup: () => void };
 			};
 
 			if (stateWithLifecycle.lifecycle) {
 				const lifecycle = stateWithLifecycle.lifecycle;
-				// Track component unmount for resource cleanup
 				cleanups.push(() => {
-					Effect.runSync(lifecycle.runCleanup());
+					lifecycle.runCleanup();
 				});
 			}
 


### PR DESCRIPTION
Closes #40
Also partially addresses #47 (Effect.Effect<void> removed from ComponentLifecycle public interface).

## Changes

**`blueprint/lifecycle.ts`**
- `ComponentLifecycle.runCleanup()` now returns `void` — Effect runs internally
- `scope: Scope.CloseableScope` removed from the public interface
- Added `getActiveLifecycle()` and `withActiveLifecycle(lifecycle, fn)` for hook registration

**`blueprint/define.ts`**
- Script fn execution wrapped in `withActiveLifecycle` so any hook calling `onMount` during component setup registers into the correct lifecycle

**`hooks/context.ts`**
- `onMount` forwards the callback into `getActiveLifecycle()` instead of pushing to a dead `mountCallbacks` array
- `mountCallbacks` array and its return from `createHookContext` removed entirely

**`blueprint/script-context.ts`**
- `ScriptState.scope` field removed (was set but never read)
- `runUnmountCallbacks` calls `lifecycle.runCleanup()` directly — no more `Effect.runSync`
- Unused `pipe`, `Effect`, `Scope`, `mapEffuseErrors` imports removed

**`services/dom-renderer/mount.ts`**
- Internal lifecycle cast updated to match new `runCleanup(): void` signature

**`__tests__/blueprint/script-context-layers.test.ts`**
- `Effect.runSync(state.lifecycle.runCleanup())` → `state.lifecycle.runCleanup()`
- `Effect` import removed

## Tests
1080/1080 passing.