### PR TITLE
feat(#45): delete EffuseLayerRegistry, EffuseServiceRegistry, EffuseComponentRegistry and dependents

### DIFF
--- a/packages/core/src/blueprint/script-context.ts
+++ b/packages/core/src/blueprint/script-context.ts
@@ -50,14 +50,13 @@ import {
 	isLayerRuntimeReady,
 	type LayerContext,
 } from '../layers/context.js';
-import type { EffuseServiceRegistry, EffuseComponentRegistry } from '../layers/types.js';
-import { RouterNotConfiguredError } from '../layers/errors.js';
-import { StoreGetterNotConfiguredError } from '../errors.js';
 import type { CompiledLayer } from '../layers/api/defineLayer.js';
 import {
 	resolveLayersAccessor,
 	type LayersAccessor,
 } from '../layers/api/layersAccessor.js';
+import { RouterNotConfiguredError } from '../layers/errors.js';
+import { StoreGetterNotConfiguredError } from '../errors.js';
 
 export type ExposedValues = object;
 
@@ -131,22 +130,11 @@ export interface ScriptContext<P, L extends readonly CompiledLayer<any>[] = []> 
 
 	useMemo: typeof useMemo;
 
-	useStore: {
-		<K extends keyof EffuseServiceRegistry>(key: K): EffuseServiceRegistry[K];
-		(key: string): unknown;
-	};
+	useStore: (key: string) => unknown;
 
-	useService: {
-		<K extends keyof EffuseServiceRegistry>(key: K): EffuseServiceRegistry[K];
-		(key: string): unknown;
-	};
+	useService: (key: string) => unknown;
 
-	useComponent: {
-		<K extends keyof EffuseComponentRegistry>(
-			name: K
-		): EffuseComponentRegistry[K];
-		(name: string): Component | undefined;
-	};
+	useComponent: (name: string) => Component | undefined;
 }
 
 export interface ScriptState<E extends ExposedValues> {

--- a/packages/core/src/layers/context.ts
+++ b/packages/core/src/layers/context.ts
@@ -27,9 +27,6 @@ import type { Component } from '../render/node.js';
 import type {
 	LayerProps,
 	AnyResolvedLayer,
-	EffuseLayerRegistry,
-	EffuseComponentRegistry,
-	LayerPropsOf,
 } from './types.js';
 import type { PropsRegistry } from './services/PropsService.js';
 import type { LayerRegistry } from './services/RegistryService.js';
@@ -46,9 +43,6 @@ export interface LayerContext<P extends LayerProps = LayerProps> {
 	getService: (key: string) => unknown;
 	getComponent: (name: string) => unknown;
 }
-
-export type TypedLayerContext<K extends keyof EffuseLayerRegistry> =
-	LayerContext<LayerPropsOf<K>>;
 
 interface GlobalLayerState {
 	propsRegistry: PropsRegistry | null;
@@ -85,10 +79,6 @@ export const isLayerRuntimeReady = (): boolean => {
 	);
 };
 
-export function getLayerContext<K extends keyof EffuseLayerRegistry>(
-	name: K
-): TypedLayerContext<K>;
-export function getLayerContext(name: string): LayerContext;
 export function getLayerContext(name: string): LayerContext {
 	if (!globalState.layerRegistry || !globalState.propsRegistry) {
 		throw new LayerRuntimeNotInitializedError({ resource: `layer "${name}"` });
@@ -142,10 +132,6 @@ export const getLayerService = (key: string): unknown => {
 	return globalState.layerRegistry.getService(key);
 };
 
-export function getLayerComponent<K extends keyof EffuseComponentRegistry>(
-	name: K
-): EffuseComponentRegistry[K];
-export function getLayerComponent(name: string): Component | undefined;
 export function getLayerComponent(name: string): Component | undefined {
 	if (!globalState.layerRegistry) {
 		return undefined;

--- a/packages/core/src/layers/index.ts
+++ b/packages/core/src/layers/index.ts
@@ -44,9 +44,6 @@ export type {
 	DepsRecord,
 	AnyLayer,
 	AnyResolvedLayer,
-	EffuseLayerRegistry,
-	LayerPropsOf,
-	LayerProvidesOf,
 } from './types.js';
 
 export {
@@ -87,7 +84,6 @@ export {
 	getLayerService,
 	isLayerRuntimeReady,
 	type LayerContext,
-	type TypedLayerContext,
 } from './context.js';
 
 export {

--- a/packages/core/src/layers/types.ts
+++ b/packages/core/src/layers/types.ts
@@ -179,20 +179,3 @@ export interface MergedConfig {
 export type AnyLayer = EffuseLayer<any, any, any>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyResolvedLayer = ResolvedLayer<any, any, any>;
-
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface EffuseLayerRegistry {}
-
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface EffuseServiceRegistry {}
-
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface EffuseComponentRegistry {}
-
-export type LayerPropsOf<K extends keyof EffuseLayerRegistry> =
-	EffuseLayerRegistry[K] extends { props: infer P extends LayerProps }
-		? P
-		: LayerProps;
-
-export type LayerProvidesOf<K extends keyof EffuseLayerRegistry> =
-	EffuseLayerRegistry[K] extends { provides: infer S } ? S : unknown;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
         specifier: ^0.3.2
         version: 0.3.2
       '@effuse/core':
-        specifier: 1.2.3
+        specifier: 1.2.4
         version: link:../core
       '@types/node':
         specifier: ^25.5.0
@@ -145,7 +145,7 @@ importers:
         specifier: ^0.3.2
         version: 0.3.2
       '@effuse/core':
-        specifier: 1.2.3
+        specifier: 1.2.4
         version: link:../core
       '@types/node':
         specifier: ^25.5.0
@@ -173,7 +173,7 @@ importers:
         specifier: ^0.3.2
         version: 0.3.2
       '@effuse/core':
-        specifier: 1.2.3
+        specifier: 1.2.4
         version: link:../core
       '@types/node':
         specifier: ^25.5.0
@@ -201,7 +201,7 @@ importers:
         specifier: ^0.3.2
         version: 0.3.2
       '@effuse/core':
-        specifier: 1.2.3
+        specifier: 1.2.4
         version: link:../core
       '@types/node':
         specifier: ^25.5.0
@@ -229,7 +229,7 @@ importers:
         specifier: ^0.3.2
         version: 0.3.2
       '@effuse/core':
-        specifier: 1.2.3
+        specifier: 1.2.4
         version: link:../core
       '@types/node':
         specifier: ^25.5.0
@@ -260,7 +260,7 @@ importers:
         specifier: ^0.3.2
         version: 0.3.2
       '@effuse/core':
-        specifier: 1.2.3
+        specifier: 1.2.4
         version: link:../core
       '@types/node':
         specifier: ^25.5.0


### PR DESCRIPTION
## Summary

- Deletes `EffuseLayerRegistry`, `EffuseServiceRegistry`, `EffuseComponentRegistry` from `layers/types.ts`
- Deletes `LayerPropsOf`, `LayerProvidesOf`, `TypedLayerContext`
- Removes registry-typed overloads from `getLayerContext` and `getLayerComponent` in `layers/context.ts`
- Simplifies `useStore`, `useService`, `useComponent` signatures to plain `string` (no module augmentation needed)
- Removes all re-exports of these types from `layers/index.ts` and `index.ts`

Closes #45