### PR TITLE
fix(#47): remove Effect.Effect<T> leaks from Canvas, PropSchemaBuilder, EffuseContext

### DIFF
--- a/packages/core/src/blueprint/props.ts
+++ b/packages/core/src/blueprint/props.ts
@@ -62,10 +62,6 @@ export interface PropSchemaBuilder<T extends Record<string, unknown>> {
 		[K in keyof T]: PropDefinition<T[K]>;
 	};
 	readonly schema: Schema.Schema<T>;
-	readonly validate: (
-		props: unknown,
-		componentName?: string
-	) => Effect.Effect<T, PropsValidationError>;
 	readonly validateSync: (props: unknown, componentName?: string) => T;
 }
 
@@ -224,7 +220,6 @@ const struct = <const D extends Record<string, PropDefinition<any>>>(
 			[K in keyof ResultType]: PropDefinition<ResultType[K]>;
 		},
 		schema: compositeSchema as unknown as Schema.Schema<ResultType>,
-		validate,
 		validateSync,
 	};
 };

--- a/packages/core/src/canvas/canvas.ts
+++ b/packages/core/src/canvas/canvas.ts
@@ -37,13 +37,6 @@ export interface Canvas {
 	render: (node: EffuseChild) => void;
 
 	dispose: () => void;
-
-	paintEffect: <P extends Record<string, unknown>>(
-		blueprint: BlueprintDef<P>,
-		props?: P
-	) => Effect.Effect<void, RenderError | MountError>;
-
-	renderEffect: (node: EffuseChild) => Effect.Effect<void, RenderError>;
 }
 
 export const canvas = (target: Element | string): Canvas => {
@@ -120,23 +113,8 @@ export const canvas = (target: Element | string): Canvas => {
 			}
 			container.innerHTML = '';
 		},
-
-		paintEffect: canvasPaintEffect,
-		renderEffect: canvasRenderEffect,
 	};
 };
-
-export const canvasEffect = (
-	target: Element | string
-): Effect.Effect<Canvas, MountError> =>
-	Effect.try({
-		try: () => canvas(target),
-		catch: (error) =>
-			new MountError({
-				message: String(error),
-				target,
-			}),
-	});
 
 export const mount = <P = Record<string, unknown>>(
 	blueprint: BlueprintDef<P>,
@@ -147,14 +125,3 @@ export const mount = <P = Record<string, unknown>>(
 	c.paint(blueprint as BlueprintDef, props as Record<string, unknown>);
 	return c;
 };
-
-export const mountEffect = <P extends Record<string, unknown>>(
-	blueprint: BlueprintDef<P>,
-	target: Element | string,
-	props?: P
-): Effect.Effect<Canvas, MountError | RenderError> =>
-	Effect.gen(function* () {
-		const c = yield* canvasEffect(target);
-		yield* c.paintEffect(blueprint, props);
-		return c;
-	});

--- a/packages/core/src/canvas/index.ts
+++ b/packages/core/src/canvas/index.ts
@@ -24,8 +24,6 @@
 
 export {
 	canvas,
-	canvasEffect,
 	mount,
-	mountEffect,
 	type Canvas,
 } from './canvas.js';

--- a/packages/core/src/context/context.ts
+++ b/packages/core/src/context/context.ts
@@ -45,8 +45,11 @@ export interface EffuseContext<T> {
 	readonly Provider: ReturnType<typeof define>;
 	readonly defaultValue: T | undefined;
 	readonly hasDefault: boolean;
-	readonly _effectTag: Context.Tag<string, T>;
 	readonly _tag: 'EffuseContext';
+}
+
+interface EffuseContextInternal<T> extends EffuseContext<T> {
+	readonly _effectTag: Context.Tag<string, T>;
 }
 
 const createdContexts = new Map<string, EffuseContext<unknown>>();
@@ -81,7 +84,7 @@ export function createContext<T>(options: ContextOptions<T>): EffuseContext<T> {
 		template: ({ children }) => children,
 	});
 
-	const context: EffuseContext<T> = {
+	const context: EffuseContextInternal<T> = {
 		id,
 		displayName,
 		Provider: Provider as ReturnType<typeof define>,
@@ -97,7 +100,7 @@ export function createContext<T>(options: ContextOptions<T>): EffuseContext<T> {
 }
 
 const getContextValue = <T>(
-	context: EffuseContext<T>
+	context: EffuseContextInternal<T>
 ): Effect.Effect<T, ContextNotFoundError> =>
 	Effect.gen(function* () {
 		// effect context
@@ -127,7 +130,7 @@ export function useContext<T>(
 ): T {
 	return Effect.runSync(
 		pipe(
-			getContextValue(context),
+			getContextValue(context as EffuseContextInternal<T>),
 			Effect.mapError((error) =>
 				componentName
 					? new ContextNotFoundError({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -145,9 +145,7 @@ export {
 
 export {
 	canvas,
-	canvasEffect,
 	mount,
-	mountEffect,
 	type Canvas,
 } from './canvas/index.js';
 


### PR DESCRIPTION
## Summary

- **Canvas**: removes `paintEffect`, `renderEffect` from `Canvas` interface; removes `canvasEffect` and `mountEffect` exports — plain `canvas()` and `mount()` are sufficient
- **PropSchemaBuilder**: removes `validate: (...) => Effect.Effect<T, PropsValidationError>` from the public interface; `validateSync` remains
- **EffuseContext**: moves `_effectTag: Context.Tag<string, T>` to the private `EffuseContextInternal` type; `EffuseContext<T>` no longer exposes Effect types

Developers now have zero need to import from `effect` to use any Effuse public API.

Closes #47