### PR TITLE
feat(#65): useMemo returns ReadonlySignal instead of getter

### DIFF
--- a/packages/core/src/__tests__/blueprint/define-props.test.ts
+++ b/packages/core/src/__tests__/blueprint/define-props.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { define } from '../../blueprint/define.js';
+import type { ReadonlySignal } from '../../types/index.js';
 import type {
 	DefineOptions,
 	DefineOptionsWithInferredProps,
@@ -1051,27 +1052,28 @@ describe('define function - props type inference', () => {
 				}
 
 				interface MemoExposed {
-					getSum: () => number;
-					getAvg: () => number;
+					sum: ReadonlySignal<number>;
+					avg: ReadonlySignal<number>;
 				}
 
 				const MemoComponent = define<MemoProps, MemoExposed>({
 					script: ({ props, useMemo }) => {
-						const getSum = useMemo(() =>
+						const sum = useMemo(() =>
 							props.items.reduce((a, b) => a + b, 0)
 						);
-						const getAvg = useMemo(() => {
-							const sum = props.items.reduce((a, b) => a + b, 0);
-							return sum / props.items.length;
+						const avg = useMemo(() => {
+							const s = props.items.reduce((a, b) => a + b, 0);
+							return s / props.items.length;
 						});
-						return { getSum, getAvg };
+						return { sum, avg };
 					},
 					template: () => null,
 				});
 
 				const blueprint = extractBlueprint(MemoComponent);
-				const state = blueprint.state({ items: [1, 2, 3, 4, 5] });
-				expect(state).toBeDefined();
+				const state = blueprint.state({ items: [1, 2, 3, 4, 5] }) as unknown as { exposed: MemoExposed };
+				expect(state.exposed.sum.value).toBe(15);
+				expect(state.exposed.avg.value).toBe(3);
 			});
 		});
 

--- a/packages/core/src/blueprint/hooks.ts
+++ b/packages/core/src/blueprint/hooks.ts
@@ -48,10 +48,10 @@ export function useCallback<T extends (...args: any[]) => any>(
 	}).value as T;
 }
 
-export function useMemo<T>(fn: () => T, deps?: unknown[]): () => T {
+export function useMemo<T>(fn: () => T, deps?: unknown[]): ReadonlySignal<T> {
 	const memoized = computed(() => {
 		trackDependencies(deps);
 		return fn();
 	});
-	return () => memoized.value;
+	return memoized;
 }


### PR DESCRIPTION
## Summary

`useMemo` now returns `ReadonlySignal<T>` instead of `() => T`, aligning with
the framework's `.value` convention used by `signal` and `computed`.

## Breaking Change

```ts
// Before
const getSum = useMemo(() => items.reduce((a, b) => a + b, 0));
return <div>{getSum()}</div>;

// After
const sum = useMemo(() => items.reduce((a, b) => a + b, 0));
return <div>{sum.value}</div>;
```

## Changes

- `blueprint/hooks.ts`: `useMemo` returns `ReadonlySignal<T>`
- `__tests__/blueprint/define-props.test.ts`: Updated test to use `.value`

## Verification

- [x] TypeScript clean (`tsc --noEmit`)
- [x] All 1165 tests passing

## Fixes

Closes #65