### PR TITLE
feat(#66): add component-level provide/inject

### DIFF
--- a/packages/core/src/__tests__/blueprint/provide-inject.test.ts
+++ b/packages/core/src/__tests__/blueprint/provide-inject.test.ts
@@ -1,0 +1,98 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+	provide,
+	inject,
+	createProvideScope,
+	runWithProvideScope,
+	getCurrentProvideScope,
+} from '../../blueprint/provide-inject.js';
+
+describe('provide / inject', () => {
+	it('should provide and inject a value in the same scope', () => {
+		const scope = createProvideScope();
+
+		const result = runWithProvideScope(scope, () => {
+			provide('theme', 'dark');
+			return inject('theme');
+		});
+
+		expect(result).toBe('dark');
+	});
+
+	it('should return default value when key not found', () => {
+		const scope = createProvideScope();
+
+		const result = runWithProvideScope(scope, () => {
+			return inject('missing', 'default');
+		});
+
+		expect(result).toBe('default');
+	});
+
+	it('should walk up parent scopes to find value', () => {
+		const parent = createProvideScope();
+		const child = createProvideScope(parent);
+
+		runWithProvideScope(parent, () => {
+			provide('user', { name: 'Chris' });
+		});
+
+		const result = runWithProvideScope(child, () => {
+			return inject('user');
+		});
+
+		expect(result).toEqual({ name: 'Chris' });
+	});
+
+	it('should prefer child scope over parent scope', () => {
+		const parent = createProvideScope();
+		const child = createProvideScope(parent);
+
+		runWithProvideScope(parent, () => {
+			provide('theme', 'light');
+		});
+
+		const result = runWithProvideScope(child, () => {
+			provide('theme', 'dark');
+			return inject('theme');
+		});
+
+		expect(result).toBe('dark');
+	});
+
+	it('should support symbol keys', () => {
+		const KEY = Symbol('secret');
+		const scope = createProvideScope();
+
+		const result = runWithProvideScope(scope, () => {
+			provide(KEY, 42);
+			return inject(KEY);
+		});
+
+		expect(result).toBe(42);
+	});
+
+	it('should return null when no scope is active', () => {
+		expect(getCurrentProvideScope()).toBeNull();
+	});
+
+	it('should warn when provide() called outside a scope in dev', () => {
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		provide('key', 'value');
+
+		if (process.env.NODE_ENV !== 'production') {
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('provide() called outside a component scope')
+			);
+		}
+
+		warnSpy.mockRestore();
+	});
+});

--- a/packages/core/src/blueprint/define.ts
+++ b/packages/core/src/blueprint/define.ts
@@ -34,6 +34,11 @@ import { createScriptContext, runMountCallbacks } from './script-context.js';
 import type { ComponentLifecycle } from './lifecycle.js';
 import { withActiveLifecycle } from './lifecycle.js';
 import type { CompiledLayer } from '../layers/api/defineLayer.js';
+import {
+	createProvideScope,
+	runWithProvideScope,
+	getCurrentProvideScope,
+} from './provide-inject.js';
 
 interface PropsWithChildren {
 	readonly children?: EffuseChild;
@@ -75,6 +80,8 @@ interface DefineState<E extends ExposedValues> {
 	_template: (exposed: TemplateArgs<E>, props: unknown) => EffuseChild;
 	/** Reactive props proxy created by script context. */
 	_reactiveProps?: Readonly<Record<string, unknown>>;
+	/** Provide scope for component-level provide/inject. */
+	_provideScope?: import('./provide-inject.js').ProvideScope;
 	[key: string]: unknown;
 }
 
@@ -98,8 +105,11 @@ export function define<
 				layers
 			);
 
-			const scriptResult = withActiveLifecycle(state.lifecycle, () =>
-				options.script(context)
+			const parentScope = getCurrentProvideScope();
+			const provideScope = createProvideScope(parentScope);
+
+			const scriptResult = runWithProvideScope(provideScope, () =>
+				withActiveLifecycle(state.lifecycle, () => options.script(context))
 			);
 
 			if (Predicate.isNotNullable(scriptResult)) {
@@ -115,6 +125,7 @@ export function define<
 				lifecycle: state.lifecycle,
 				_template: options.template,
 				_reactiveProps: context.props as Readonly<Record<string, unknown>>,
+				_provideScope: provideScope,
 			} as DefineState<E> as unknown as Record<string, never>;
 		},
 

--- a/packages/core/src/blueprint/provide-inject.ts
+++ b/packages/core/src/blueprint/provide-inject.ts
@@ -1,0 +1,78 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export interface ProvideScope {
+	readonly parent: ProvideScope | null;
+	readonly values: Map<symbol | string, unknown>;
+}
+
+const provideStorage = new AsyncLocalStorage<ProvideScope>();
+
+export const createProvideScope = (
+	parent: ProvideScope | null = null
+): ProvideScope => ({
+	parent,
+	values: new Map(),
+});
+
+export const runWithProvideScope = <T>(
+	scope: ProvideScope,
+	fn: () => T
+): T => {
+	return provideStorage.run(scope, fn);
+};
+
+export const getCurrentProvideScope = (): ProvideScope | null => {
+	return provideStorage.getStore() ?? null;
+};
+
+export const provide = <T>(key: symbol | string, value: T): void => {
+	const scope = getCurrentProvideScope();
+	if (!scope) {
+		if (process.env.NODE_ENV !== 'production') {
+			console.warn(
+				'[Effuse] provide() called outside a component scope. ' +
+					'Call it inside a script() function.'
+			);
+		}
+		return;
+	}
+	scope.values.set(key, value);
+};
+
+export const inject = <T>(
+	key: symbol | string,
+	defaultValue?: T
+): T | undefined => {
+	let scope = getCurrentProvideScope();
+	while (scope) {
+		if (scope.values.has(key)) {
+			return scope.values.get(key) as T;
+		}
+		scope = scope.parent;
+	}
+	return defaultValue;
+};

--- a/packages/core/src/blueprint/script-context.ts
+++ b/packages/core/src/blueprint/script-context.ts
@@ -45,6 +45,7 @@ import {
 } from './lifecycle.js';
 import { useCallback, useMemo } from './hooks.js';
 import { createReactiveProps } from './reactive-props.js';
+import { provide, inject } from './provide-inject.js';
 import {
 	getLayerComponent,
 	getLayerService,
@@ -136,6 +137,10 @@ export interface ScriptContext<P, L extends readonly CompiledLayer<any>[] = []> 
 	useService: (key: string) => unknown;
 
 	useComponent: (name: string) => Component | undefined;
+
+	provide: typeof provide;
+
+	inject: typeof inject;
 }
 
 export interface ScriptState<E extends ExposedValues> {
@@ -300,6 +305,10 @@ export const createScriptContext = <
 			}
 			return getLayerComponent(name) as Component | undefined;
 		},
+
+		provide,
+
+		inject,
 	};
 
 	return { context, state };

--- a/packages/core/src/services/dom-renderer/mount.ts
+++ b/packages/core/src/services/dom-renderer/mount.ts
@@ -39,6 +39,7 @@ import {
 	type EventBindingResult,
 } from './events.js';
 import { instantiateBlueprint } from '../../blueprint/blueprint.js';
+import { runWithProvideScope } from '../../blueprint/provide-inject.js';
 import type { BlueprintContext } from '../../schema/node.js';
 import { isSuspendToken } from '../../suspense/Suspense.js';
 import { isEffuseNode } from '../../render/index.js';
@@ -480,6 +481,7 @@ const mountNode = (
 
 			const stateWithLifecycle = context.state as unknown as {
 				lifecycle?: { runCleanup: () => void };
+				_provideScope?: import('../../blueprint/provide-inject.js').ProvideScope;
 			};
 
 			if (stateWithLifecycle.lifecycle) {
@@ -489,7 +491,11 @@ const mountNode = (
 				});
 			}
 
-			const childView = node.blueprint.view(context as BlueprintContext);
+			const childView = stateWithLifecycle._provideScope
+				? runWithProvideScope(stateWithLifecycle._provideScope, () =>
+						node.blueprint.view(context as BlueprintContext)
+					)
+				: node.blueprint.view(context as BlueprintContext);
 			return mountChild(childView, cleanups);
 		}
 		default: {

--- a/packages/core/src/ssr/render.ts
+++ b/packages/core/src/ssr/render.ts
@@ -26,6 +26,7 @@ import { Predicate, pipe } from 'effect';
 import type { EffuseNode, Component, BlueprintDef } from '../render/node.js';
 import { isEffuseNode, matchEffuseNode } from '../render/node.js';
 import { isSignal } from '../reactivity/index.js';
+import { runWithProvideScope } from '../blueprint/provide-inject.js';
 import type { HeadProps, RenderResult, ServerAppOptions } from './types.js';
 import { RenderError } from './errors.js';
 import { headToHtml } from './head-registry.js';
@@ -231,7 +232,12 @@ const renderBlueprint = (
 		portals: {},
 	};
 
-	const viewResult = def.view(context);
+	const provideScope = (state as unknown as { _provideScope?: import('../blueprint/provide-inject.js').ProvideScope })._provideScope;
+
+	const viewResult = provideScope
+		? runWithProvideScope(provideScope, () => def.view(context))
+		: def.view(context);
+
 	return renderNodeToString(viewResult);
 };
 


### PR DESCRIPTION
## Summary

Adds Vue-like `provide()` / `inject()` to the script context, enabling
component-level dependency injection without global layers.

## Usage

```ts
const Parent = define({
  script: ({ provide }) => {
    provide('theme', 'dark');
    return {};
  },
  template: () => <Child />
});

const Child = define({
  script: ({ inject }) => {
    const theme = inject('theme', 'light');
    return { theme };
  },
  template: ({ theme }) => <div>{theme}</div>
});
```

## Changes

- **blueprint/provide-inject.ts**: New utility with `AsyncLocalStorage` scope
  hierarchy. Supports string and symbol keys, parent scope resolution,
  child-scope shadowing, and default values.
- **blueprint/script-context.ts**: Exposes `provide` and `inject` on
  `ScriptContext`.
- **blueprint/define.ts**: Wraps script execution in a per-component provide
  scope that inherits from the parent.
- **services/dom-renderer/mount.ts**: Runs blueprint `view()` inside the
  component's provide scope so template-injected children see provided values.
- **ssr/render.ts**: Same for SSR rendering.

## Verification

- [x] TypeScript clean (`tsc --noEmit`)
- [x] All 1172 tests passing (7 new provide/inject tests)

## Fixes

Closes #66