### PR TITLE
feat(#67): Add development warnings system

### DIFF
--- a/packages/core/src/__tests__/blueprint/dev-warnings.test.ts
+++ b/packages/core/src/__tests__/blueprint/dev-warnings.test.ts
@@ -1,0 +1,127 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useCallback, useMemo } from '../../blueprint/hooks.js';
+import { createReactiveProps } from '../../blueprint/reactive-props.js';
+import { provide, inject, createProvideScope, runWithProvideScope } from '../../blueprint/provide-inject.js';
+import { withActiveLifecycle, createComponentLifecycleSync } from '../../blueprint/lifecycle.js';
+
+describe('dev warnings', () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		warnSpy.mockRestore();
+	});
+
+	describe('missing prop key', () => {
+		it('should warn when accessing a prop key that was not provided', () => {
+			const { proxy } = createReactiveProps<{ name: string }>({ name: 'Effuse' });
+
+			// @ts-expect-error — accessing missing prop
+			void proxy.missingKey;
+
+			if (process.env.NODE_ENV !== 'production') {
+				expect(warnSpy).toHaveBeenCalledWith(
+					expect.stringContaining('Accessed missing prop "missingKey"')
+				);
+			}
+		});
+
+		it('should not warn when accessing an existing prop key', () => {
+			const { proxy } = createReactiveProps<{ name: string }>({ name: 'Effuse' });
+
+			void proxy.name;
+
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('hooks outside lifecycle', () => {
+		it('should warn when useCallback is called outside a lifecycle', () => {
+			useCallback(() => 42);
+
+			if (process.env.NODE_ENV !== 'production') {
+				expect(warnSpy).toHaveBeenCalledWith(
+					expect.stringContaining('useCallback() called outside a component lifecycle')
+				);
+			}
+		});
+
+		it('should warn when useMemo is called outside a lifecycle', () => {
+			useMemo(() => 42);
+
+			if (process.env.NODE_ENV !== 'production') {
+				expect(warnSpy).toHaveBeenCalledWith(
+					expect.stringContaining('useMemo() called outside a component lifecycle')
+				);
+			}
+		});
+
+		it('should not warn when useCallback is called inside an active lifecycle', () => {
+			const lifecycle = createComponentLifecycleSync();
+			withActiveLifecycle(lifecycle, () => {
+				useCallback(() => 42);
+			});
+
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not warn when useMemo is called inside an active lifecycle', () => {
+			const lifecycle = createComponentLifecycleSync();
+			withActiveLifecycle(lifecycle, () => {
+				useMemo(() => 42);
+			});
+
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('inject without provider', () => {
+		it('should warn when inject() returns undefined with no default and no scope', () => {
+			inject('theme');
+
+			if (process.env.NODE_ENV !== 'production') {
+				expect(warnSpy).toHaveBeenCalledWith(
+					expect.stringContaining('inject("theme") returned undefined')
+				);
+			}
+		});
+
+		it('should warn when inject() returns undefined with no default inside a scope', () => {
+			const scope = createProvideScope();
+			runWithProvideScope(scope, () => {
+				inject('theme');
+			});
+
+			if (process.env.NODE_ENV !== 'production') {
+				expect(warnSpy).toHaveBeenCalledWith(
+					expect.stringContaining('inject("theme") returned undefined')
+				);
+			}
+		});
+
+		it('should not warn when inject() has a default value', () => {
+			inject('theme', 'dark');
+
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not warn when inject() finds a provided value', () => {
+			const scope = createProvideScope();
+			runWithProvideScope(scope, () => {
+				provide('theme', 'dark');
+				inject('theme');
+			});
+
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/core/src/blueprint/hooks.ts
+++ b/packages/core/src/blueprint/hooks.ts
@@ -26,6 +26,8 @@ import { Array as Arr, Predicate } from 'effect';
 import { computed } from '../reactivity/computed.js';
 import { isSignal } from '../reactivity/signal.js';
 import type { ReadonlySignal } from '../types/index.js';
+import { getActiveLifecycle } from './lifecycle.js';
+import { devWarn } from '../utils/dev-warnings.js';
 
 const trackDependencies = (deps: unknown[] | undefined): void => {
 	if (!Predicate.isNotNullable(deps)) return;
@@ -36,11 +38,21 @@ const trackDependencies = (deps: unknown[] | undefined): void => {
 	});
 };
 
+const warnIfOutsideLifecycle = (hookName: string): void => {
+	if (!getActiveLifecycle()) {
+		devWarn(
+			`${hookName}() called outside a component lifecycle. ` +
+				`Hooks should only be called inside a script() function.`
+		);
+	}
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function useCallback<T extends (...args: any[]) => any>(
 	fn: T,
 	deps?: unknown[]
 ): T {
+	warnIfOutsideLifecycle('useCallback');
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 	return computed(() => {
 		trackDependencies(deps);
@@ -49,6 +61,7 @@ export function useCallback<T extends (...args: any[]) => any>(
 }
 
 export function useMemo<T>(fn: () => T, deps?: unknown[]): ReadonlySignal<T> {
+	warnIfOutsideLifecycle('useMemo');
 	const memoized = computed(() => {
 		trackDependencies(deps);
 		return fn();

--- a/packages/core/src/blueprint/provide-inject.ts
+++ b/packages/core/src/blueprint/provide-inject.ts
@@ -23,6 +23,7 @@
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { devWarn } from '../utils/dev-warnings.js';
 
 export interface ProvideScope {
 	readonly parent: ProvideScope | null;
@@ -52,12 +53,10 @@ export const getCurrentProvideScope = (): ProvideScope | null => {
 export const provide = <T>(key: symbol | string, value: T): void => {
 	const scope = getCurrentProvideScope();
 	if (!scope) {
-		if (process.env.NODE_ENV !== 'production') {
-			console.warn(
-				'[Effuse] provide() called outside a component scope. ' +
-					'Call it inside a script() function.'
-			);
-		}
+		devWarn(
+			'provide() called outside a component scope. ' +
+				'Call it inside a script() function.'
+		);
 		return;
 	}
 	scope.values.set(key, value);
@@ -73,6 +72,13 @@ export const inject = <T>(
 			return scope.values.get(key) as T;
 		}
 		scope = scope.parent;
+	}
+	if (defaultValue === undefined) {
+		devWarn(
+			`inject(${typeof key === 'symbol' ? key.toString() : `"${key}"`}) ` +
+				`returned undefined because no provider was found. ` +
+				`Pass a default value, or ensure a parent component calls provide().`
+		);
 	}
 	return defaultValue;
 };

--- a/packages/core/src/blueprint/reactive-props.ts
+++ b/packages/core/src/blueprint/reactive-props.ts
@@ -24,6 +24,7 @@
 
 import { signal } from '../reactivity/index.js';
 import type { Signal } from '../reactivity/signal.js';
+import { devWarn } from '../utils/dev-warnings.js';
 
 export interface ReactiveProps<P extends Record<string, unknown>> {
 	/** Readonly reactive proxy — each read tracks the underlying signal. */
@@ -55,16 +56,20 @@ export const createReactiveProps = <P extends Record<string, unknown>>(
 		get(_, key: string | symbol) {
 			if (typeof key === 'symbol') return undefined;
 			const sig = signals.get(key);
+			if (sig === undefined) {
+				devWarn(
+					`Accessed missing prop "${key}". ` +
+						`Did you forget to pass it, or is this a typo?`
+				);
+			}
 			return sig !== undefined ? sig.value : undefined;
 		},
 		set(_, key: string | symbol) {
 			if (typeof key === 'string') {
-				if (process.env.NODE_ENV !== 'production') {
-					console.warn(
-						`[Effuse] Attempted to mutate prop "${key}". Props are readonly. ` +
-							`Use local state (signal/computed) or emit events to the parent instead.`
-					);
-				}
+				devWarn(
+					`Attempted to mutate prop "${key}". Props are readonly. ` +
+						`Use local state (signal/computed) or emit events to the parent instead.`
+				);
 			}
 			return true;
 		},

--- a/packages/core/src/layers/context.ts
+++ b/packages/core/src/layers/context.ts
@@ -35,6 +35,7 @@ import {
 	LayerNotFoundError,
 	LayerRuntimeNotInitializedError,
 } from './errors.js';
+import { devWarn } from '../utils/dev-warnings.js';
 
 export interface LayerContext<P extends LayerProps = LayerProps> {
 	readonly name: string;
@@ -89,6 +90,11 @@ export const clearGlobalLayerContext = (): void => {
 const getStoreOrThrow = (): LayerContextStore => {
 	const store = layerContextStorage.getStore();
 	if (!store) {
+		devWarn(
+			'Layer runtime not initialized. ' +
+				'Did you forget to call app.useLayers() or createSSRRuntime()?' +
+				' If testing, wrap your code in runWithLayerContext(store, fn).'
+		);
 		throw new LayerRuntimeNotInitializedError({ resource: 'layer context' });
 	}
 	return store;

--- a/packages/core/src/utils/dev-warnings.ts
+++ b/packages/core/src/utils/dev-warnings.ts
@@ -1,0 +1,37 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const isDev = process.env.NODE_ENV !== 'production';
+
+export const devWarn = (message: string): void => {
+	if (isDev) {
+		console.warn(`[Effuse] ${message}`);
+	}
+};
+
+export const devError = (message: string): void => {
+	if (isDev) {
+		console.error(`[Effuse] ${message}`);
+	}
+};


### PR DESCRIPTION
## Summary

Closes #67 — adds a centralized development warnings system and covers the major DX gaps identified in the analysis.

## Changes

- **New utility** `packages/core/src/utils/dev-warnings.ts` with `devWarn` / `devError` helpers that are no-ops in production.
- **Refactored existing warnings** in `layers/context.ts`, `blueprint/reactive-props.ts`, and `blueprint/provide-inject.ts` to use the new utility instead of inline `console.warn` checks.
- **New warnings added:**
  - `useCallback` / `useMemo` called outside an active component lifecycle.
  - Accessing a prop key that was never provided (catches typos and missing props).
  - `inject()` returning `undefined` because no provider was found and no default was given.
- **Tests** `packages/core/src/__tests__/blueprint/dev-warnings.test.ts` with 10 assertions covering all new warnings.

## Verification

- `packages/core` test suite: **1083 passed** (10 new).
- No breaking changes — all warnings are dev-only and do not alter runtime behavior.