### PR TITLE
feat(#67): Auto-generate layer hooks and cleaner template API

### DIFF
--- a/packages/core/src/__tests__/blueprint/define-props-single-arg.test.ts
+++ b/packages/core/src/__tests__/blueprint/define-props-single-arg.test.ts
@@ -1,0 +1,80 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ */
+
+import { describe, it, expect } from 'vitest';
+import { define, defineProps } from '../../blueprint/define.js';
+
+describe('defineProps', () => {
+	it('should return an empty object at runtime', () => {
+		const props = defineProps<{ name: string; count: number }>();
+		expect(props).toEqual({});
+	});
+
+	it('should work inside define() for type inference', () => {
+		const Comp = define({
+			props: defineProps<{ title: string }>(),
+			script: ({ props }) => {
+				return { greeting: `Hello, ${props.title}` };
+			},
+			template: (ctx) => ctx.greeting,
+		});
+
+		const blueprint = Comp as unknown as {
+			state: (props: Record<string, unknown>) => Record<string, unknown>;
+			view: (ctx: { props: Record<string, unknown>; state: Record<string, unknown> }) => unknown;
+		};
+
+		const state = blueprint.state({ title: 'World' });
+		const rendered = blueprint.view({ props: { title: 'World' }, state });
+
+		expect(rendered).toBe('Hello, World');
+	});
+});
+
+describe('single-arg template context', () => {
+	it('should merge exposed values and props into one context', () => {
+		let capturedCtx: unknown;
+
+		const Comp = define({
+			props: { label: 'default' },
+			script: ({ props }) => {
+				return { doubled: (props.label as string).repeat(2) };
+			},
+			template: (ctx) => {
+				capturedCtx = ctx;
+				return `${ctx.doubled}-${ctx.label}`;
+			},
+		});
+
+		const blueprint = Comp as unknown as {
+			state: (props: Record<string, unknown>) => Record<string, unknown>;
+			view: (ctx: { props: Record<string, unknown>; state: Record<string, unknown> }) => unknown;
+		};
+
+		const state = blueprint.state({ label: 'A' });
+		const rendered = blueprint.view({ props: { label: 'A' }, state });
+
+		expect(rendered).toBe('AA-A');
+		expect(capturedCtx).toMatchObject({ label: 'A', doubled: 'AA' });
+	});
+
+	it('should include children in the merged context', () => {
+		const Comp = define({
+			script: () => ({ count: 1 }),
+			template: (ctx) => ctx.children,
+		});
+
+		const blueprint = Comp as unknown as {
+			state: (props: Record<string, unknown>) => Record<string, unknown>;
+			view: (ctx: { props: Record<string, unknown>; state: Record<string, unknown> }) => unknown;
+		};
+
+		const state = blueprint.state({});
+		const rendered = blueprint.view({ props: { children: 'child-content' }, state });
+
+		expect(rendered).toBe('child-content');
+	});
+});

--- a/packages/core/src/__tests__/blueprint/define-props.test.ts
+++ b/packages/core/src/__tests__/blueprint/define-props.test.ts
@@ -363,8 +363,8 @@ describe('define function - props type inference', () => {
 				script: ({ props }) => {
 					return { computed: `${props.title}-${String(props.count)}` };
 				},
-				template: (_exposed, props) => {
-					capturedProps = props;
+				template: (ctx) => {
+					capturedProps = ctx;
 					return null;
 				},
 			});
@@ -375,7 +375,7 @@ describe('define function - props type inference', () => {
 
 			blueprint.view({ props: testProps, state });
 
-			expect(capturedProps).toEqual(testProps);
+			expect(capturedProps).toMatchObject(testProps);
 		});
 	});
 
@@ -1387,9 +1387,9 @@ describe('define function - props type inference', () => {
 					script: () => {
 						return { subtitle: 'Subtitle' };
 					},
-					template: (exposed, props) => {
-						capturedTitle = props.title;
-						capturedSubtitle = exposed.subtitle;
+					template: (ctx) => {
+						capturedTitle = ctx.title;
+						capturedSubtitle = ctx.subtitle;
 						return null;
 					},
 				});

--- a/packages/core/src/__tests__/blueprint/layer-hooks.test.ts
+++ b/packages/core/src/__tests__/blueprint/layer-hooks.test.ts
@@ -1,0 +1,60 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ */
+
+import { describe, it, expect } from 'vitest';
+import { useLayerService } from '../../blueprint/hooks.js';
+import { defineLayer } from '../../layers/api/defineLayer.js';
+import { runWithLayerContext } from '../../layers/context.js';
+import type { PropsRegistry } from '../../layers/services/PropsService.js';
+import type { LayerRegistry } from '../../layers/services/RegistryService.js';
+
+describe('useLayerService', () => {
+	it('should return a service when layer runtime is initialized', () => {
+		const authSvc = { login: () => 'ok' };
+
+		const authLayer = defineLayer({
+			name: 'auth',
+			provides: { authSvc: () => authSvc },
+		});
+
+		const layerRegistry = {
+			getLayer: () => undefined,
+			getService: (key: string) => (key === 'authSvc' ? authSvc : undefined),
+			getComponent: () => undefined,
+		} as unknown as LayerRegistry;
+
+		const propsRegistry = {} as unknown as PropsRegistry;
+
+		const result = runWithLayerContext(
+			{ propsRegistry, layerRegistry, layers: [] },
+			() => useLayerService(authLayer, 'authSvc')
+		);
+
+		expect(result).toBe(authSvc);
+	});
+
+	it('should return undefined when service is not found', () => {
+		const authLayer = defineLayer({
+			name: 'auth',
+			provides: {},
+		});
+
+		const layerRegistry = {
+			getLayer: () => undefined,
+			getService: () => undefined,
+			getComponent: () => undefined,
+		} as unknown as LayerRegistry;
+
+		const propsRegistry = {} as unknown as PropsRegistry;
+
+		const result = runWithLayerContext(
+			{ propsRegistry, layerRegistry, layers: [] },
+			() => useLayerService(authLayer, 'missing')
+		);
+
+		expect(result).toBeUndefined();
+	});
+});

--- a/packages/core/src/__tests__/blueprint/reactive-props.test.ts
+++ b/packages/core/src/__tests__/blueprint/reactive-props.test.ts
@@ -144,8 +144,8 @@ describe('reactive props — blueprint integration', () => {
 		const Component = define({
 			props: { label: 'default' },
 			script: () => ({ greeting: 'hi' }),
-			template: (_exposed, props) => {
-				capturedProps = props;
+			template: (ctx) => {
+				capturedProps = ctx;
 				return null;
 			},
 		});

--- a/packages/core/src/blueprint/define.ts
+++ b/packages/core/src/blueprint/define.ts
@@ -48,6 +48,11 @@ export type TemplateArgs<E extends ExposedValues> = E & {
 	readonly children?: EffuseChild;
 };
 
+/** Merged template context: exposed values + props + children. */
+export type TemplateContext<E extends ExposedValues, P> = E & Readonly<P> & {
+	readonly children?: EffuseChild;
+};
+
 export interface DefineOptionsWithInferredProps<
 	P,
 	E extends ExposedValues,
@@ -58,7 +63,7 @@ export interface DefineOptionsWithInferredProps<
 	props: P;
 	layers?: L;
 	script: (ctx: ScriptContext<P, L>) => E | undefined;
-	template: (exposed: TemplateArgs<E>, props: Readonly<P>) => EffuseChild;
+	template: (ctx: TemplateContext<E, P>) => EffuseChild;
 }
 
 export interface DefineOptions<
@@ -71,13 +76,13 @@ export interface DefineOptions<
 	props?: undefined;
 	layers?: L;
 	script: (ctx: ScriptContext<P, L>) => E | undefined;
-	template: (exposed: TemplateArgs<E>, props: Readonly<P>) => EffuseChild;
+	template: (ctx: TemplateContext<E, P>) => EffuseChild;
 }
 
 interface DefineState<E extends ExposedValues> {
 	exposed: E;
 	lifecycle: ComponentLifecycle;
-	_template: (exposed: TemplateArgs<E>, props: unknown) => EffuseChild;
+	_template: (ctx: TemplateContext<E, unknown>) => EffuseChild;
 	/** Reactive props proxy created by script context. */
 	_reactiveProps?: Readonly<Record<string, unknown>>;
 	/** Provide scope for component-level provide/inject. */
@@ -133,12 +138,13 @@ export function define<
 			const state = ctx.state as unknown as DefineState<E>;
 
 			const propsWithChildren = ctx.props as unknown as PropsWithChildren;
-			const exposedWithChildren: TemplateArgs<E> = {
+			const mergedCtx: TemplateContext<E, P> = {
 				...state.exposed,
+				...ctx.props,
 				children: propsWithChildren.children,
-			};
+			} as unknown as TemplateContext<E, P>;
 
-			return state._template(exposedWithChildren, ctx.props);
+			return state._template(mergedCtx);
 		},
 	};
 
@@ -154,3 +160,19 @@ export type InferProps<D> =
 		: D extends DefineOptions<infer P, ExposedValues>
 			? P
 			: never;
+
+/**
+ * Type-only helper for declaring component props without dummy runtime values.
+ *
+ * Returns an empty object at runtime — type checking happens at compile time.
+ *
+ * @example
+ * ```ts
+ * const Comp = define({
+ *   props: defineProps<{ name: string; count: number }>(),
+ *   script: ({ props }) => { … },
+ *   template: (ctx) => <div>{ctx.name}</div>,
+ * });
+ * ```
+ */
+export const defineProps = <P>(): P => ({} as P);

--- a/packages/core/src/blueprint/hooks.ts
+++ b/packages/core/src/blueprint/hooks.ts
@@ -28,6 +28,8 @@ import { isSignal } from '../reactivity/signal.js';
 import type { ReadonlySignal } from '../types/index.js';
 import { getActiveLifecycle } from './lifecycle.js';
 import { devWarn } from '../utils/dev-warnings.js';
+import { getLayerService } from '../layers/context.js';
+import type { CompiledLayer, EffuseLayer, EffuseServices } from '../layers/api/defineLayer.js';
 
 const trackDependencies = (deps: unknown[] | undefined): void => {
 	if (!Predicate.isNotNullable(deps)) return;
@@ -68,3 +70,24 @@ export function useMemo<T>(fn: () => T, deps?: unknown[]): ReadonlySignal<T> {
 	});
 	return memoized;
 }
+
+/**
+ * Typed helper to retrieve a service from a layer at runtime.
+ *
+ * The layer argument is used only for type inference — the actual lookup
+ * uses the string key against the active layer registry.
+ *
+ * @example
+ * ```ts
+ * const auth = useLayerService(AuthLayer, 'authSvc');
+ * ```
+ */
+export const useLayerService = <
+	T extends EffuseLayer,
+	K extends keyof EffuseServices<T>,
+>(
+	_layer: CompiledLayer<T, string>,
+	key: K
+): EffuseServices<T>[K] | undefined => {
+	return getLayerService(key as string) as EffuseServices<T>[K] | undefined;
+};

--- a/packages/core/src/blueprint/index.ts
+++ b/packages/core/src/blueprint/index.ts
@@ -32,11 +32,13 @@ export {
 
 export {
 	define,
+	defineProps,
 	type DefineOptions,
 	type DefineOptionsWithInferredProps,
 	type InferExposed,
 	type InferProps,
 	type TemplateArgs,
+	type TemplateContext,
 } from './define.js';
 export {
 	type ScriptContext,
@@ -75,4 +77,4 @@ export {
 	PORTAL_PRIORITY,
 } from './portal.js';
 
-export { useCallback, useMemo } from './hooks.js';
+export { useCallback, useMemo, useLayerService } from './hooks.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,11 +112,13 @@ export { EFFUSE_NODE, FRAGMENT, NodeType } from './constants.js';
 export {
 	blueprint,
 	define,
+	defineProps,
 	isBlueprint,
 	instantiateBlueprint,
 	type BlueprintOptions,
 	type DefineOptions,
 	type DefineOptionsWithInferredProps,
+	type TemplateContext,
 	type ScriptContext,
 	type EffuseRegistry,
 	setGlobalStoreGetter,
@@ -141,6 +143,7 @@ export {
 	type PortalInsertMode,
 	type PortalPriority,
 	PORTAL_PRIORITY,
+	useLayerService,
 } from './blueprint/index.js';
 
 export {


### PR DESCRIPTION
## Summary

Closes #67 — implements the three DX improvements identified in the issue:

1. **`useLayerService(layer, key)` typed helper** — replaces deeply nested `ctx.layers.auth.services.authSvc` with clean, type-safe service access.
2. **Single-arg template context** — `template: (ctx) => ...` now receives a merged context containing exposed values, props, and children. No more `(exposed, props)` confusion.
3. **`defineProps<P>()` type helper** — declare props without dummy runtime values. Returns `{}` at runtime; TypeScript infers `P` from the generic parameter.

## Changes

- `packages/core/src/blueprint/define.ts`
  - Added `TemplateContext<E, P>` type
  - Changed `template` signature from `(exposed, props)` to `(ctx)`
  - Updated `view()` to merge `exposed`, `props`, and `children` into one context object
  - Added `defineProps<P>()

- `packages/core/src/blueprint/hooks.ts`
  - Added `useLayerService<T, K>(layer, key)` with inference from `EffuseServices<T>`

- Blueprint and core index exports updated for `defineProps`, `useLayerService`, `TemplateContext`

## Tests

- `layer-hooks.test.ts` — 2 tests for `useLayerService`
- `define-props-single-arg.test.ts` — 4 tests for `defineProps` and merged template context
- All existing tests updated to single-arg template where needed
- Full core suite: **1089 passed**

## Breaking Change

Template functions now receive a single merged context argument instead of two separate arguments. Components using the old `(exposed, props)` pattern will need to be updated to `(ctx)`.