### PR TITLE
fix(router): Link template signature and history browser safety (#94, #95)

### DIFF
--- a/packages/router/src/__tests__/useRoute.test.ts
+++ b/packages/router/src/__tests__/useRoute.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { useRoute } from '../utils/composables.js';
 import { RouterNotInstalledError } from '../errors.js';
 import { createRouter, installRouter } from '../core/router.js';
+import { createMemoryHistory } from '../core/history.js';
 import { clearContext } from '../core/context.js';
 import { define } from '@effuse/core';
 
@@ -16,6 +17,7 @@ describe('useRoute', () => {
 
 	it('should return the current route if router is installed', () => {
 		const router = createRouter({
+			history: createMemoryHistory('/'),
 			routes: [
 				{
 					path: '/',

--- a/packages/router/src/components/Link.ts
+++ b/packages/router/src/components/Link.ts
@@ -125,28 +125,28 @@ export const Link = define<LinkProps, LinkState>({
 		};
 	},
 
-	template: (exposed, props): ElementNode => {
+	template: (ctx): ElementNode => {
 		const userClass =
-			(typeof props.class === 'string' && props.class) ||
-			(typeof props.className === 'string' && props.className) ||
+			(typeof ctx.class === 'string' && ctx.class) ||
+			(typeof ctx.className === 'string' && ctx.className) ||
 			'';
 
 		const classSig = computed<string | null>(() => {
 			const classes: string[] = [];
 			if (userClass) classes.push(userClass);
-			if (exposed.isExactActive.value) {
-				classes.push(exposed.exactActiveClass);
-			} else if (exposed.isActive.value) {
-				classes.push(exposed.activeClass);
+			if (ctx.isExactActive.value) {
+				classes.push(ctx.exactActiveClass);
+			} else if (ctx.isActive.value) {
+				classes.push(ctx.activeClass);
 			}
 			return classes.length > 0 ? classes.join(' ') : null;
 		});
 
 		const ariaCurrentSig = computed<string | null>(() =>
-			exposed.isExactActive.value ? 'page' : null
+			ctx.isExactActive.value ? 'page' : null
 		);
 
-		const childrenProp = (props as { children?: unknown }).children;
+		const childrenProp = (ctx as unknown as { children?: unknown }).children;
 		const childrenArr =
 			childrenProp == null
 				? []
@@ -158,9 +158,9 @@ export const Link = define<LinkProps, LinkState>({
 			[EFFUSE_NODE]: true,
 			tag: 'a',
 			props: {
-				href: exposed.to,
+				href: ctx.to,
 				className: classSig,
-				onClick: exposed.handleClick,
+				onClick: ctx.handleClick,
 				'aria-current': ariaCurrentSig,
 			},
 			children: childrenArr,

--- a/packages/router/src/core/history.ts
+++ b/packages/router/src/core/history.ts
@@ -32,34 +32,43 @@ export interface RouterHistory {
 	readonly getCurrentPath: () => string;
 }
 
+const isBrowser = (): boolean => typeof window !== 'undefined';
+
 export const createWebHistory = (base: string = ''): RouterHistory => {
 	const normalizeBase = base.replace(/\/$/, '');
 
 	return {
 		push: (path: string) => {
+			if (!isBrowser()) return;
 			window.history.pushState({}, '', normalizeBase + path);
 			window.dispatchEvent(new PopStateEvent('popstate'));
 		},
 		replace: (path: string) => {
+			if (!isBrowser()) return;
 			window.history.replaceState({}, '', normalizeBase + path);
 			window.dispatchEvent(new PopStateEvent('popstate'));
 		},
 		go: (delta: number) => {
+			if (!isBrowser()) return;
 			window.history.go(delta);
 		},
 		back: () => {
+			if (!isBrowser()) return;
 			window.history.back();
 		},
 		forward: () => {
+			if (!isBrowser()) return;
 			window.history.forward();
 		},
 		listen: (callback: () => void) => {
+			if (!isBrowser()) return () => {};
 			window.addEventListener('popstate', callback);
 			return () => {
 				window.removeEventListener('popstate', callback);
 			};
 		},
 		getCurrentPath: () => {
+			if (!isBrowser()) return '/';
 			const path =
 				window.location.pathname +
 				window.location.search +
@@ -72,32 +81,70 @@ export const createWebHistory = (base: string = ''): RouterHistory => {
 export const createHashHistory = (): RouterHistory => {
 	return {
 		push: (path: string) => {
+			if (!isBrowser()) return;
 			window.location.hash = path;
 		},
 		replace: (path: string) => {
+			if (!isBrowser()) return;
 			const url = new URL(window.location.href);
 			url.hash = path;
 			window.history.replaceState({}, '', url.toString());
 			window.dispatchEvent(new HashChangeEvent('hashchange'));
 		},
 		go: (delta: number) => {
+			if (!isBrowser()) return;
 			window.history.go(delta);
 		},
 		back: () => {
+			if (!isBrowser()) return;
 			window.history.back();
 		},
 		forward: () => {
+			if (!isBrowser()) return;
 			window.history.forward();
 		},
 		listen: (callback: () => void) => {
+			if (!isBrowser()) return () => {};
 			window.addEventListener('hashchange', callback);
 			return () => {
 				window.removeEventListener('hashchange', callback);
 			};
 		},
 		getCurrentPath: () => {
+			if (!isBrowser()) return '/';
 			const hash = window.location.hash.slice(1) || '/';
 			return hash;
 		},
+	};
+};
+
+/** Memory history for testing and SSR environments. */
+export const createMemoryHistory = (initialPath: string = '/'): RouterHistory => {
+	let currentPath = initialPath;
+	const listeners = new Set<() => void>();
+
+	const notify = () => {
+		for (const cb of listeners) cb();
+	};
+
+	return {
+		push: (path: string) => {
+			currentPath = path;
+			notify();
+		},
+		replace: (path: string) => {
+			currentPath = path;
+			notify();
+		},
+		go: () => {},
+		back: () => {},
+		forward: () => {},
+		listen: (callback: () => void) => {
+			listeners.add(callback);
+			return () => {
+				listeners.delete(callback);
+			};
+		},
+		getCurrentPath: () => currentPath,
 	};
 };

--- a/packages/router/src/core/router.ts
+++ b/packages/router/src/core/router.ts
@@ -242,13 +242,15 @@ export const createRouter = (options: RouterOptions): RouterInstance => {
 
 			updateRouteSignal(newRoute);
 
-			window.dispatchEvent(
-				new CustomEvent('effuse:route-change', { detail: newRoute })
-			);
+			if (typeof window !== 'undefined') {
+				window.dispatchEvent(
+					new CustomEvent('effuse:route-change', { detail: newRoute })
+				);
+			}
 
 			Effect.runFork(runAfterHooks(guards.afterEach, newRoute, from));
 
-			if (config.scrollToTop && !opts.replace) {
+			if (config.scrollToTop && !opts.replace && typeof window !== 'undefined') {
 				window.scrollTo(0, 0);
 			}
 


### PR DESCRIPTION
## Summary

Fixes two router issues that break TypeScript compilation and tests in non-browser environments.

## Changes

### Link component template signature (#94)
The blueprint refactor changed `define()` to expect `template: (ctx: TemplateContext<E, P>) => EffuseChild`. `Link` was still using the old `(exposed, props)` two-arg signature, causing a TS2322 error.

Rewrote `Link.template` to use the merged single-argument `ctx` with destructured property access.

### Browser-safe history adapters (#95)
`createWebHistory` and `createHashHistory` unconditionally accessed `window`, causing `ReferenceError: window is not defined` in Node/vitest and SSR.

- Added `isBrowser()` helper and guarded all `window` access
- In non-browser: `getCurrentPath()` returns `'/'`, `push`/`replace` are no-ops, `listen` returns empty cleanup
- Added `createMemoryHistory(initialPath)` for testing and SSR
- Guarded `window.dispatchEvent` and `window.scrollTo` in `createRouter.navigate()`

## Verification

```bash
npx tsc --noEmit -p packages/router/tsconfig.json
# 0 errors

npx vitest run packages/router/src/__tests__/useRoute.test.ts
# 1 test file | 2 passed
```

Closes #94, closes #95