### PR TITLE
fix(i18n): robust localStorage check for Node 22+ test environment (#96)

### DIFF
--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -53,6 +53,11 @@ import {
 	LOCALE_STORAGE_KEY,
 } from './config/constants.js';
 
+const hasLocalStorage = (): boolean =>
+	typeof localStorage !== 'undefined' &&
+	typeof localStorage.getItem === 'function' &&
+	typeof localStorage.setItem === 'function';
+
 let globalI18nInstance: I18nInstance | null = null;
 
 class I18nInstance implements I18n {
@@ -83,7 +88,7 @@ class I18nInstance implements I18n {
 		}
 
 		const persistEnabled = options.persistLocale ?? envConfig.persistLocale;
-		if (persistEnabled && typeof localStorage !== 'undefined') {
+		if (persistEnabled && hasLocalStorage()) {
 			const stored = localStorage.getItem(LOCALE_STORAGE_KEY);
 			if (
 				Predicate.isNotNullable(stored) &&
@@ -151,7 +156,7 @@ class I18nInstance implements I18n {
 
 		const persistEnabled =
 			this._options.persistLocale ?? getI18nConfig().persistLocale;
-		if (persistEnabled && typeof localStorage !== 'undefined') {
+		if (persistEnabled && hasLocalStorage()) {
 			localStorage.setItem(LOCALE_STORAGE_KEY, locale);
 		}
 


### PR DESCRIPTION
## Summary

Node 22+ provides an experimental `localStorage` global when `--experimental-localstorage` is enabled. The object exists but `getItem`/`setItem` are not proper functions, causing all 36 i18n tests to fail with:

```
TypeError: localStorage.getItem is not a function
```

## Fix

Added `hasLocalStorage()` helper that verifies:
1. `localStorage` is defined
2. `localStorage.getItem` is a function
3. `localStorage.setItem` is a function

Applied to both the constructor (read path) and `setLocale` (write path).

## Verification

```bash
npx vitest run packages/i18n/src/i18n.test.ts
# 1 test file | 37 passed
```

Closes #96