### PR TITLE
fix(router): ranked matching, multi-value query, trailing slashes, comprehensive tests (#105, #110, #112, #116)

### DIFF
--- a/packages/router/src/__tests__/composables.test.ts
+++ b/packages/router/src/__tests__/composables.test.ts
@@ -1,0 +1,107 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useRouter, useRoute, onRouteChange } from '../utils/composables.js';
+import { createRouter, installRouter } from '../core/router.js';
+import { createMemoryHistory } from '../core/history.js';
+import { clearContext } from '../core/context.js';
+import { define } from '@effuse/core';
+
+const dummyComponent = define({
+	script: () => ({}),
+	template: () => 'test',
+});
+
+describe('useRouter', () => {
+	beforeEach(() => {
+		clearContext();
+	});
+
+	it('should throw when router not installed', () => {
+		expect(() => useRouter()).toThrow();
+	});
+
+	it('should return router when installed', () => {
+		const router = createRouter({
+			history: createMemoryHistory('/'),
+			routes: [{ path: '/', component: dummyComponent }],
+		});
+		installRouter(router);
+		expect(useRouter()).toBe(router);
+	});
+});
+
+describe('useRoute', () => {
+	beforeEach(() => {
+		clearContext();
+	});
+
+	it('should throw when router not installed', () => {
+		expect(() => useRoute()).toThrow();
+	});
+
+	it('should return current route', () => {
+		const router = createRouter({
+			history: createMemoryHistory('/'),
+			routes: [{ path: '/', name: 'home', component: dummyComponent }],
+		});
+		installRouter(router);
+		const route = useRoute();
+		expect(route.path).toBe('/');
+		expect(route.name).toBe('home');
+	});
+
+	it('should reflect route changes after navigation', () => {
+		const router = createRouter({
+			history: createMemoryHistory('/'),
+			routes: [
+				{ path: '/', component: dummyComponent },
+				{ path: '/about', name: 'about', component: dummyComponent },
+			],
+		});
+		installRouter(router);
+		router.push('/about');
+		const route = useRoute();
+		expect(route.path).toBe('/about');
+		expect(route.name).toBe('about');
+	});
+});
+
+describe('onRouteChange', () => {
+	beforeEach(() => {
+		clearContext();
+	});
+
+	it('should call callback on route change', () => {
+		const router = createRouter({
+			history: createMemoryHistory('/'),
+			routes: [
+				{ path: '/', component: dummyComponent },
+				{ path: '/about', component: dummyComponent },
+			],
+		});
+		installRouter(router);
+		const cb = vi.fn();
+		const stop = onRouteChange(cb);
+		router.push('/about');
+		expect(cb).toHaveBeenCalled();
+		stop();
+	});
+
+	it('should not call callback for same route', () => {
+		const router = createRouter({
+			history: createMemoryHistory('/'),
+			routes: [{ path: '/', component: dummyComponent }],
+		});
+		installRouter(router);
+		const cb = vi.fn();
+		const stop = onRouteChange(cb);
+		router.push('/'); // same path
+		expect(cb).not.toHaveBeenCalled();
+		stop();
+	});
+});

--- a/packages/router/src/__tests__/guards.test.ts
+++ b/packages/router/src/__tests__/guards.test.ts
@@ -1,0 +1,164 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createRouter } from '../core/router.js';
+import { createMemoryHistory } from '../core/history.js';
+import {
+	NavigationResult,
+	combineGuards,
+	guardWhen,
+	createAuthGuard,
+} from '../navigation/guards.js';
+import {
+	NavigationFailure,
+} from '../navigation/errors.js';
+import { clearContext } from '../core/context.js';
+import { define } from '@effuse/core';
+
+const dummyComponent = define({
+	script: () => ({}),
+	template: () => 'test',
+});
+
+describe('NavigationResult', () => {
+	it('should create allowed result', () => {
+		const result = NavigationResult.allowed();
+		expect(NavigationResult.isAllowed(result)).toBe(true);
+	});
+
+	it('should create cancelled result', () => {
+		const result = NavigationResult.cancelled('nope');
+		expect(NavigationResult.isCancelled(result)).toBe(true);
+	});
+
+	it('should create redirected result', () => {
+		const result = NavigationResult.redirected('/login');
+		expect(NavigationResult.isRedirected(result)).toBe(true);
+	});
+
+	it('should create failed result', () => {
+		const result = NavigationResult.failed(new Error('oops'));
+		expect(NavigationResult.isFailed(result)).toBe(true);
+	});
+});
+
+describe('createRouter guards', () => {
+	beforeEach(() => {
+		clearContext();
+	});
+
+	it('should allow navigation when no guards', () => {
+		const router = createRouter({
+			history: createMemoryHistory('/'),
+			routes: [{ path: '/', component: dummyComponent }],
+		});
+		const result = router.push('/');
+		expect(NavigationFailure.isNavigationFailure(result)).toBe(true); // duplicated (same path)
+	});
+
+	it('should call beforeEach guard', () => {
+		const guard = vi.fn(() => NavigationResult.allowed());
+		const router = createRouter({
+			history: createMemoryHistory('/'),
+			routes: [
+				{ path: '/', component: dummyComponent },
+				{ path: '/about', component: dummyComponent },
+			],
+		});
+		router.beforeEach(guard);
+		router.push('/about');
+		expect(guard).toHaveBeenCalled();
+	});
+
+	it('should cancel navigation when guard returns cancelled', () => {
+		const router = createRouter({
+			history: createMemoryHistory('/'),
+			routes: [
+				{ path: '/', component: dummyComponent },
+				{ path: '/admin', component: dummyComponent },
+			],
+		});
+		router.beforeEach(() => NavigationResult.cancelled('blocked'));
+		const result = router.push('/admin');
+		expect(NavigationFailure.isNavigationFailure(result)).toBe(true);
+	});
+
+	it('should redirect navigation when guard returns redirect', () => {
+		const router = createRouter({
+			history: createMemoryHistory('/'),
+			routes: [
+				{ path: '/', component: dummyComponent },
+				{ path: '/login', component: dummyComponent },
+				{ path: '/admin', component: dummyComponent },
+			],
+		});
+		router.beforeEach((to) => {
+			if (to.path === '/admin') {
+				return NavigationResult.redirected('/login');
+			}
+			return NavigationResult.allowed();
+		});
+		const result = router.push('/admin');
+		// Should redirect to /login
+		expect(result).toBeDefined();
+	});
+
+	it('should remove guard on cleanup', () => {
+		const guard = vi.fn(() => NavigationResult.allowed());
+		const router = createRouter({
+			history: createMemoryHistory('/'),
+			routes: [
+				{ path: '/', component: dummyComponent },
+				{ path: '/about', component: dummyComponent },
+			],
+		});
+		const cleanup = router.beforeEach(guard);
+		cleanup();
+		router.push('/about');
+		expect(guard).not.toHaveBeenCalled();
+	});
+});
+
+describe('guard utilities', () => {
+	it('combineGuards should stop on first rejection', async () => {
+		const combined = combineGuards(
+			() => NavigationResult.allowed(),
+			() => NavigationResult.cancelled('stop')
+		);
+		const result = await combined({} as any, {} as any);
+		expect(NavigationResult.isCancelled(result)).toBe(true);
+	});
+
+	it('guardWhen should conditionally run guard', async () => {
+		const guard = vi.fn(() => NavigationResult.cancelled());
+		const conditional = guardWhen(() => true, guard);
+		await conditional({} as any, {} as any);
+		expect(guard).toHaveBeenCalled();
+
+		const skip = guardWhen(() => false, guard);
+		const result = await skip({} as any, {} as any);
+		expect(NavigationResult.isAllowed(result)).toBe(true);
+	});
+
+	it('createAuthGuard should redirect when not authenticated', async () => {
+		const authGuard = createAuthGuard(() => false, '/login');
+		const result = await authGuard(
+			{ meta: { requiresAuth: true } } as any,
+			{} as any
+		);
+		expect(NavigationResult.isRedirected(result)).toBe(true);
+	});
+
+	it('createAuthGuard should allow when authenticated', async () => {
+		const authGuard = createAuthGuard(() => true, '/login');
+		const result = await authGuard(
+			{ meta: { requiresAuth: true } } as any,
+			{} as any
+		);
+		expect(NavigationResult.isAllowed(result)).toBe(true);
+	});
+});

--- a/packages/router/src/__tests__/history.test.ts
+++ b/packages/router/src/__tests__/history.test.ts
@@ -1,0 +1,84 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+	createWebHistory,
+	createHashHistory,
+	createMemoryHistory,
+} from '../core/history.js';
+
+describe('createMemoryHistory', () => {
+	it('should return initial path', () => {
+		const history = createMemoryHistory('/start');
+		expect(history.getCurrentPath()).toBe('/start');
+	});
+
+	it('should push new path', () => {
+		const history = createMemoryHistory('/');
+		history.push('/about');
+		expect(history.getCurrentPath()).toBe('/about');
+	});
+
+	it('should replace path', () => {
+		const history = createMemoryHistory('/');
+		history.replace('/contact');
+		expect(history.getCurrentPath()).toBe('/contact');
+	});
+
+	it('should notify listeners on push', () => {
+		const history = createMemoryHistory('/');
+		const listener = vi.fn();
+		history.listen(listener);
+		history.push('/about');
+		expect(listener).toHaveBeenCalledTimes(1);
+	});
+
+	it('should remove listener on cleanup', () => {
+		const history = createMemoryHistory('/');
+		const listener = vi.fn();
+		const cleanup = history.listen(listener);
+		cleanup();
+		history.push('/about');
+		expect(listener).not.toHaveBeenCalled();
+	});
+});
+
+describe('createWebHistory (browser environment)', () => {
+	it('should return / in non-browser', () => {
+		const history = createWebHistory();
+		expect(history.getCurrentPath()).toBe('/');
+	});
+
+	it('should be no-op in non-browser', () => {
+		const history = createWebHistory();
+		expect(() => history.push('/about')).not.toThrow();
+		expect(() => history.replace('/about')).not.toThrow();
+		expect(() => history.back()).not.toThrow();
+		expect(() => history.forward()).not.toThrow();
+		expect(() => history.go(1)).not.toThrow();
+	});
+
+	it('should return empty cleanup in non-browser', () => {
+		const history = createWebHistory();
+		const cleanup = history.listen(() => {});
+		expect(typeof cleanup).toBe('function');
+		expect(() => cleanup()).not.toThrow();
+	});
+});
+
+describe('createHashHistory (browser environment)', () => {
+	it('should return / in non-browser', () => {
+		const history = createHashHistory();
+		expect(history.getCurrentPath()).toBe('/');
+	});
+
+	it('should be no-op in non-browser', () => {
+		const history = createHashHistory();
+		expect(() => history.push('/about')).not.toThrow();
+		expect(() => history.replace('/about')).not.toThrow();
+	});
+});

--- a/packages/router/src/__tests__/route-matching.test.ts
+++ b/packages/router/src/__tests__/route-matching.test.ts
@@ -1,0 +1,212 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	matchRoute,
+	resolveRoute,
+	normalizeRoutes,
+	parseQuery,
+	stringifyQuery,
+	parseUrl,
+} from '../core/route.js';
+
+const makeRoutes = (paths: string[]) =>
+	normalizeRoutes(
+		paths.map((path) => ({ path, component: () => path }))
+	);
+
+describe('route matching', () => {
+	describe('ranked matching', () => {
+		it('should prefer static over dynamic segments', () => {
+			const routes = makeRoutes(['/teams/:id', '/teams/new']);
+			const result = matchRoute('/teams/new', routes);
+			expect(result.matched[result.matched.length - 1].path).toBe('/teams/new');
+		});
+
+		it('should prefer more specific routes regardless of definition order', () => {
+			const routes = makeRoutes(['/:a/:b', '/foo/bar']);
+			const result = matchRoute('/foo/bar', routes);
+			expect(result.matched[result.matched.length - 1].path).toBe('/foo/bar');
+		});
+
+		it('should still match dynamic when no static alternative', () => {
+			const routes = makeRoutes(['/teams/:id', '/teams/new']);
+			const result = matchRoute('/teams/123', routes);
+			expect(result.matched[result.matched.length - 1].path).toBe('/teams/:id');
+			expect(result.params).toEqual({ id: '123' });
+		});
+
+		it('should prefer routes with more static segments', () => {
+			const routes = makeRoutes(['/a', '/a/b']);
+			const result = matchRoute('/a/b', routes);
+			expect(result.matched[result.matched.length - 1].path).toBe('/a/b');
+		});
+	});
+
+	describe('params', () => {
+		it('should extract single param', () => {
+			const routes = makeRoutes(['/user/:id']);
+			const result = matchRoute('/user/42', routes);
+			expect(result.params).toEqual({ id: '42' });
+		});
+
+		it('should extract multiple params', () => {
+			const routes = makeRoutes(['/user/:userId/post/:postId']);
+			const result = matchRoute('/user/7/post/99', routes);
+			expect(result.params).toEqual({ userId: '7', postId: '99' });
+		});
+
+		it('should handle optional param', () => {
+			const routes = makeRoutes(['/docs/:section?']);
+			const withParam = matchRoute('/docs/api', routes);
+			expect(withParam.params).toEqual({ section: 'api' });
+
+			const withoutParam = matchRoute('/docs', routes);
+			expect(withoutParam.params).toEqual({ section: '' });
+		});
+
+		it('should return empty params for no match', () => {
+			const routes = makeRoutes(['/user/:id']);
+			const result = matchRoute('/product/42', routes);
+			expect(result.matched).toHaveLength(0);
+			expect(result.params).toEqual({});
+		});
+	});
+
+	describe('trailing slashes', () => {
+		it('should match route with trailing slash', () => {
+			const routes = makeRoutes(['/about']);
+			const result = matchRoute('/about/', routes);
+			expect(result.matched).toHaveLength(1);
+		});
+
+		it('should match route without trailing slash', () => {
+			const routes = makeRoutes(['/about']);
+			const result = matchRoute('/about', routes);
+			expect(result.matched).toHaveLength(1);
+		});
+	});
+
+	describe('nested routes', () => {
+		it('should return parent chain in matched', () => {
+			const routes = normalizeRoutes([
+				{
+					path: '/parent',
+					component: () => 'parent',
+					children: [
+						{
+							path: 'child',
+							component: () => 'child',
+						},
+					],
+				},
+			]);
+			const result = matchRoute('/parent/child', routes);
+			expect(result.matched).toHaveLength(2);
+			expect(result.matched[0].path).toBe('/parent');
+			expect(result.matched[1].path).toBe('child');
+		});
+	});
+});
+
+describe('resolveRoute', () => {
+	it('should resolve string location', () => {
+		const routes = makeRoutes(['/']);
+		const resolved = resolveRoute('/about?name=test', routes);
+		expect(resolved.path).toBe('/about');
+		expect(resolved.query.name).toBe('test');
+	});
+
+	it('should resolve named location with params', () => {
+		const routes = normalizeRoutes([
+			{ path: '/user/:id', name: 'user', component: () => 'user' },
+		]);
+		const resolved = resolveRoute({ name: 'user', params: { id: '42' } }, routes);
+		expect(resolved.path).toBe('/user/42');
+		expect(resolved.name).toBe('user');
+	});
+
+	it('should throw for unknown named route', () => {
+		const routes = makeRoutes(['/']);
+		expect(() => resolveRoute({ name: 'missing' }, routes)).toThrow();
+	});
+
+	it('should merge meta from matched routes', () => {
+		const routes = normalizeRoutes([
+			{
+				path: '/admin',
+				component: () => 'admin',
+				meta: { requiresAuth: true },
+				children: [
+					{
+						path: 'dashboard',
+						component: () => 'dashboard',
+						meta: { title: 'Dashboard' },
+					},
+				],
+			},
+		]);
+		const resolved = resolveRoute('/admin/dashboard', routes);
+		expect(resolved.meta).toEqual({ requiresAuth: true, title: 'Dashboard' });
+	});
+});
+
+describe('parseQuery', () => {
+	it('should parse simple query', () => {
+		const q = parseQuery('?foo=bar&baz=qux');
+		expect(q).toEqual({ foo: 'bar', baz: 'qux' });
+	});
+
+	it('should handle multi-value keys', () => {
+		const q = parseQuery('?tag=a&tag=b&tag=c');
+		expect(q.tag).toEqual(['a', 'b', 'c']);
+	});
+
+	it('should mix single and multi values', () => {
+		const q = parseQuery('?category=tech&tag=a&tag=b');
+		expect(q.category).toBe('tech');
+		expect(q.tag).toEqual(['a', 'b']);
+	});
+
+	it('should return empty object for empty string', () => {
+		expect(parseQuery('')).toEqual({});
+		expect(parseQuery('?')).toEqual({});
+	});
+});
+
+describe('stringifyQuery', () => {
+	it('should stringify simple query', () => {
+		expect(stringifyQuery({ foo: 'bar' })).toBe('?foo=bar');
+	});
+
+	it('should stringify array values', () => {
+		expect(stringifyQuery({ tag: ['a', 'b'] })).toBe('?tag=a&tag=b');
+	});
+
+	it('should return empty string for empty object', () => {
+		expect(stringifyQuery({})).toBe('');
+	});
+});
+
+describe('parseUrl', () => {
+	it('should preserve trailing slashes', () => {
+		const url = parseUrl('/about/');
+		expect(url.pathname).toBe('/about/');
+	});
+
+	it('should normalize multiple slashes', () => {
+		const url = parseUrl('/about//page');
+		expect(url.pathname).toBe('/about/page');
+	});
+
+	it('should extract query and hash', () => {
+		const url = parseUrl('/search?q=test#results');
+		expect(url.pathname).toBe('/search');
+		expect(url.query.q).toBe('test');
+		expect(url.hash).toBe('#results');
+	});
+});

--- a/packages/router/src/core/route.ts
+++ b/packages/router/src/core/route.ts
@@ -70,7 +70,7 @@ export interface ResolvedRoute {
 	readonly path: string;
 	readonly fullPath: string;
 	readonly params: Record<string, string>;
-	readonly query: Record<string, string>;
+	readonly query: Record<string, string | string[]>;
 	readonly hash: string;
 	readonly matched: readonly NormalizedRouteRecord[];
 	readonly name: string | undefined;
@@ -82,7 +82,7 @@ export interface Route {
 	readonly path: string;
 	readonly fullPath: string;
 	readonly params: Record<string, string>;
-	readonly query: Record<string, string>;
+	readonly query: Record<string, string | string[]>;
 	readonly hash: string;
 	readonly matched: readonly NormalizedRouteRecord[];
 	readonly name: string | undefined;
@@ -106,25 +106,42 @@ export type NavigationGuard = (
 
 export type NavigationHookCleanup = () => void;
 
-export const parseQuery = (search: string): Record<string, string> => {
-	const query: Record<string, string> = {};
+export const parseQuery = (search: string): Record<string, string | string[]> => {
+	const query: Record<string, string | string[]> = {};
 	if (!search || search === '?') return query;
 	const searchString = search.startsWith('?') ? search.slice(1) : search;
-	new URLSearchParams(searchString).forEach((value, key) => {
-		query[key] = value;
-	});
+	const params = new URLSearchParams(searchString);
+	for (const [key, value] of params) {
+		const existing = query[key];
+		if (existing === undefined) {
+			query[key] = value;
+		} else if (Array.isArray(existing)) {
+			existing.push(value);
+		} else {
+			query[key] = [existing, value];
+		}
+	}
 	return query;
 };
 
-export const stringifyQuery = (query: Record<string, string>): string => {
-	const params = new URLSearchParams(query);
+export const stringifyQuery = (query: Record<string, string | string[]>): string => {
+	const params = new URLSearchParams();
+	for (const [key, value] of Object.entries(query)) {
+		if (Array.isArray(value)) {
+			for (const v of value) {
+				params.append(key, v);
+			}
+		} else if (value !== undefined) {
+			params.set(key, value);
+		}
+	}
 	const str = params.toString();
 	return str ? `?${str}` : '';
 };
 
 export const parseUrl = (
 	url: string
-): { pathname: string; query: Record<string, string>; hash: string } => {
+): { pathname: string; query: Record<string, string | string[]>; hash: string } => {
 	const hashIndex = url.indexOf('#');
 	const hash = hashIndex >= 0 ? url.slice(hashIndex) : '';
 	const urlWithoutHash = hashIndex >= 0 ? url.slice(0, hashIndex) : url;
@@ -134,26 +151,67 @@ export const parseUrl = (
 		queryIndex >= 0 ? urlWithoutHash.slice(0, queryIndex) : urlWithoutHash;
 	const queryString = queryIndex >= 0 ? urlWithoutHash.slice(queryIndex) : '';
 
-	const normalizedPathname =
-		(pathname || '/').replace(/\/+/g, '/').replace(/\/$/, '') || '/';
+	const normalizedPathname = (pathname || '/').replace(/\/+/g, '/');
 
 	return { pathname: normalizedPathname, query: parseQuery(queryString), hash };
 };
 
 const pathToRegex = (path: string): { regex: RegExp; paramNames: string[] } => {
 	const paramNames: string[] = [];
-	const regexPattern = path
-		.replace(/\*/g, '.*')
+	// Process optional params first, then required params, then wildcards
+	let regexPattern = path
 		.replace(/:([^/]+)\?/g, (_: string, paramName: string) => {
 			paramNames.push(paramName);
-			return '([^/]*)';
+			return '<<OPT>>';
 		})
 		.replace(/:([^/]+)/g, (_: string, paramName: string) => {
 			paramNames.push(paramName);
-			return '([^/]+)';
+			return '<<REQ>>';
 		})
-		.replace(/\//g, '\\/');
+		.replace(/\*/g, '.*');
+
+	// Escape slashes
+	regexPattern = regexPattern.replace(/\//g, '\\/');
+
+	// Replace markers with actual regex patterns
+	// For optional params, the preceding slash is also optional
+	regexPattern = regexPattern
+		.replace(/\\\/<<OPT>>/g, '(?:\\/([^/]*))?')
+		.replace(/<<OPT>>/g, '([^/]*)?')
+		.replace(/<<REQ>>/g, '([^/]+)');
+
 	return { regex: new RegExp(`^${regexPattern}$`), paramNames };
+};
+
+/**
+ * Score a route path for ranked matching.
+ * Higher score = more specific = should match first.
+ *
+ * Scoring:
+ * - Static segment: 4 points
+ * - Dynamic param (:id): 2 points
+ * - Optional param (:id?): 1 point
+ * - Catch-all (*): 0 points
+ *
+ * More segments always outrank fewer segments at the same specificity.
+ */
+const scoreRoute = (path: string): number => {
+	const segments = path.split('/').filter(Boolean);
+	let score = 0;
+	for (const segment of segments) {
+		if (segment === '*') {
+			score += 0;
+		} else if (segment.startsWith(':') && segment.endsWith('?')) {
+			score += 1;
+		} else if (segment.startsWith(':')) {
+			score += 2;
+		} else {
+			score += 4;
+		}
+	}
+	// More segments = higher base score to ensure /a/b outranks /a
+	score += segments.length * 0.1;
+	return score;
 };
 
 const normalizeRouteRecord = (
@@ -189,6 +247,9 @@ export const normalizeRoutes = (
 		}
 	}
 
+	// Sort by specificity: static > dynamic > optional > catch-all
+	result.sort((a, b) => scoreRoute(b.fullPath) - scoreRoute(a.fullPath));
+
 	return result;
 };
 
@@ -196,22 +257,30 @@ export const matchRoute = (
 	pathname: string,
 	normalizedRoutes: readonly NormalizedRouteRecord[]
 ): { matched: NormalizedRouteRecord[]; params: Record<string, string> } => {
-	for (const route of normalizedRoutes) {
-		const match = pathname.match(route.regex);
-		if (match) {
-			const params: Record<string, string> = {};
-			route.paramNames.forEach((name, index) => {
-				params[name] = match[index + 1] ?? '';
-			});
+	// Try pathname as-is, and also without trailing slash (for matching /about/ against /about)
+	const pathVariants = [pathname];
+	if (pathname !== '/' && pathname.endsWith('/')) {
+		pathVariants.push(pathname.slice(0, -1));
+	}
 
-			const matched: NormalizedRouteRecord[] = [];
-			let current: NormalizedRouteRecord | undefined = route;
-			while (current) {
-				matched.unshift(current);
-				current = current.parent;
+	for (const path of pathVariants) {
+		for (const route of normalizedRoutes) {
+			const match = path.match(route.regex);
+			if (match) {
+				const params: Record<string, string> = {};
+				route.paramNames.forEach((name, index) => {
+					params[name] = match[index + 1] ?? '';
+				});
+
+				const matched: NormalizedRouteRecord[] = [];
+				let current: NormalizedRouteRecord | undefined = route;
+				while (current) {
+					matched.unshift(current);
+					current = current.parent;
+				}
+
+				return { matched, params };
 			}
-
-			return { matched, params };
 		}
 	}
 	return { matched: [], params: {} };
@@ -223,7 +292,7 @@ export const resolveRoute = (
 	_currentRoute?: Route
 ): ResolvedRoute => {
 	let pathname: string;
-	let query: Record<string, string> = {};
+	let query: Record<string, string | string[]> = {};
 	let hash = '';
 	let params: Record<string, string> = {};
 

--- a/packages/router/src/navigation/guards.ts
+++ b/packages/router/src/navigation/guards.ts
@@ -105,10 +105,11 @@ export const runGuards = (
 ): Effect.Effect<NavigationResult> =>
 	Effect.gen(function* () {
 		for (const guard of guards) {
-			const result = yield* Effect.promise(async () => {
-				const res = guard(to, from);
-				return res instanceof Promise ? res : res;
-			});
+			const res = guard(to, from);
+			const result =
+				res instanceof Promise
+					? yield* Effect.promise(() => res)
+					: res;
 			if (!NavigationResult.isAllowed(result)) {
 				return result;
 			}


### PR DESCRIPTION
## Summary

Foundation-level router fixes addressing 4 critical gaps before the router can be considered production-ready.

## Changes

### Ranked route matching (#105)
Replaced order-dependent matching with scored ranking. Static segments (4 pts) outrank dynamic params (2 pts), which outrank optional params (1 pt), which outrank catch-all `*` (0 pts). More segments also contribute to a higher score.

**Before:** `/teams/:id` defined before `/teams/new` → `/teams/new` matched as `:id='new'`
**After:** `/teams/new` always matches `/teams/new` regardless of definition order

### Multi-value query params (#110)
`parseQuery` now collects arrays for repeated keys:
```ts
parseQuery('?tag=a&tag=b') // { tag: ['a', 'b'] }
```
`stringifyQuery` correctly serializes arrays back to repeated keys.

### Trailing slash preservation (#116)
- `parseUrl` no longer strips trailing slashes
- `matchRoute` tries both the exact pathname and without trailing slash
- `/about/` and `/about` both match `/about`

### Optional param regex fix
`/docs/:section?` now correctly matches both `/docs/api` and `/docs`.

### Guard sync/async fix
`runGuards` only uses `Effect.promise` when a guard actually returns a Promise, preventing `AsyncFiberException` on synchronous guards.

### Test coverage (#112)
Added 55 tests across 4 new test files:
- `route-matching.test.ts` — ranked matching, params, nested routes, query/hash parsing
- `history.test.ts` — memory history, web/hash history browser safety
- `guards.test.ts` — beforeEach, cancellation, redirect, guard utilities
- `composables.test.ts` — useRouter, useRoute, onRouteChange

## Verification

```bash
npx vitest run packages/router/src/__tests__
# 5 test files | 57 passed

npx tsc --noEmit -p packages/router/tsconfig.json
# 0 errors
```

Closes #105, closes #110, closes #112, closes #116