### PR TITLE
fix(router): lazy route resolution, granular useRoute reactivity, beforeEnter guards (#106, #107, #109)

### DIFF
--- a/packages/router/src/__tests__/guards.test.ts
+++ b/packages/router/src/__tests__/guards.test.ts
@@ -121,6 +121,84 @@ describe('createRouter guards', () => {
 		router.push('/about');
 		expect(guard).not.toHaveBeenCalled();
 	});
+
+	it('should call beforeEnter guard on matched route', () => {
+		const beforeEnter = vi.fn(() => NavigationResult.allowed());
+		const router = createRouter({
+			history: createMemoryHistory('/'),
+			routes: [
+				{ path: '/', component: dummyComponent },
+				{ path: '/admin', component: dummyComponent, beforeEnter },
+			],
+		});
+		router.push('/admin');
+		expect(beforeEnter).toHaveBeenCalled();
+	});
+
+	it('should cancel navigation when beforeEnter returns cancelled', () => {
+		const router = createRouter({
+			history: createMemoryHistory('/'),
+			routes: [
+				{ path: '/', component: dummyComponent },
+				{
+					path: '/admin',
+					component: dummyComponent,
+					beforeEnter: () => NavigationResult.cancelled('no access'),
+				},
+			],
+		});
+		const result = router.push('/admin');
+		expect(NavigationFailure.isNavigationFailure(result)).toBe(true);
+	});
+
+	it('should redirect when beforeEnter returns redirect', () => {
+		const router = createRouter({
+			history: createMemoryHistory('/'),
+			routes: [
+				{ path: '/', component: dummyComponent },
+				{ path: '/login', component: dummyComponent },
+				{
+					path: '/admin',
+					component: dummyComponent,
+					beforeEnter: (to) =>
+						to.path === '/admin'
+							? NavigationResult.redirected('/login')
+							: NavigationResult.allowed(),
+				},
+			],
+		});
+		const result = router.push('/admin');
+		expect(NavigationFailure.isNavigationFailure(result)).toBe(false);
+		expect((result as { path: string }).path).toBe('/login');
+	});
+
+	it('should run beforeEnter after beforeEach and before beforeResolve', () => {
+		const order: string[] = [];
+		const router = createRouter({
+			history: createMemoryHistory('/'),
+			routes: [
+				{ path: '/', component: dummyComponent },
+				{
+					path: '/admin',
+					component: dummyComponent,
+					beforeEnter: () => {
+						order.push('beforeEnter');
+						return NavigationResult.allowed();
+					},
+				},
+			],
+		});
+		router.beforeEach(() => {
+			order.push('beforeEach');
+			return NavigationResult.allowed();
+		});
+		router.beforeResolve(() => {
+			order.push('beforeResolve');
+			return NavigationResult.allowed();
+		});
+		router.push('/admin');
+		expect(order).toEqual(['beforeEach', 'beforeEnter', 'beforeResolve']);
+	});
 });
 
 describe('guard utilities', () => {

--- a/packages/router/src/__tests__/route-matching.test.ts
+++ b/packages/router/src/__tests__/route-matching.test.ts
@@ -111,6 +111,26 @@ describe('route matching', () => {
 			expect(result.matched[1].path).toBe('child');
 		});
 	});
+
+	describe('lazy components', () => {
+		it('should preserve lazy component in normalized route', () => {
+			const lazyComponent = () => Promise.resolve({ default: () => 'lazy' });
+			const routes = normalizeRoutes([
+				{ path: '/lazy', component: lazyComponent },
+			]);
+			expect(routes[0].component).toBe(lazyComponent);
+		});
+
+		it('should match route with lazy component', () => {
+			const lazyComponent = () => Promise.resolve({ default: () => 'lazy' });
+			const routes = normalizeRoutes([
+				{ path: '/lazy', component: lazyComponent },
+			]);
+			const result = matchRoute('/lazy', routes);
+			expect(result.matched).toHaveLength(1);
+			expect(result.matched[0].path).toBe('/lazy');
+		});
+	});
 });
 
 describe('resolveRoute', () => {

--- a/packages/router/src/components/RouterView.ts
+++ b/packages/router/src/components/RouterView.ts
@@ -38,6 +38,7 @@ import type {
 	Route,
 	NormalizedRouteRecord,
 	RouteComponent,
+	LazyRouteComponent,
 } from '../core/route.js';
 import { InvalidRouterStateError } from '../errors.js';
 
@@ -45,16 +46,22 @@ const getMatchedComponent = (
 	route: Route,
 	depth: number,
 	name: string
-): RouteComponent | null => {
+): RouteComponent | LazyRouteComponent | null => {
 	const matched = route.matched[depth];
 	if (!matched) return null;
 
 	if (matched.components) {
-		return (matched.components[name] as RouteComponent | undefined) ?? null;
+		return (
+			(matched.components[name] as
+				| RouteComponent
+				| LazyRouteComponent
+				| undefined) ?? null
+		);
 	}
 
 	return name === 'default'
-		? ((matched.component as RouteComponent | undefined) ?? null)
+		? ((matched.component as RouteComponent | LazyRouteComponent | undefined) ??
+				null)
 		: null;
 };
 
@@ -165,6 +172,61 @@ export const RouterView = define({
 			}
 
 			const props = getComponentProps(route, matched);
+
+			// Handle lazy components
+			if (Predicate.isFunction(component)) {
+				const result = component({ ...props, ...route.params });
+				if (result instanceof Promise) {
+					lastRoutePath = currentRoutePath;
+					matchedView.value = CreateElementNode({
+						[EFFUSE_NODE]: true,
+						tag: 'div',
+						props: { class: 'router-view-loading' },
+						children: [],
+					});
+
+					result
+						.then((mod) => {
+							const resolved = mod.default;
+							if (routeSignal.value.fullPath !== currentRoutePath) return;
+							const rendered = renderComponent(resolved, route, props);
+							matchedView.value = CreateElementNode({
+								[EFFUSE_NODE]: true,
+								tag: 'div',
+								key: `route-${String(depth)}-${currentRoutePath}`,
+								props: {
+									class: 'router-view-content',
+								},
+								children: [rendered],
+							});
+						})
+						.catch(() => {
+							if (routeSignal.value.fullPath !== currentRoutePath) return;
+							matchedView.value = CreateElementNode({
+								[EFFUSE_NODE]: true,
+								tag: 'div',
+								props: { class: 'router-view-error' },
+								children: ['Failed to load component'],
+							});
+						});
+					return;
+				}
+
+				// Sync function component
+				const content = CreateElementNode({
+					[EFFUSE_NODE]: true,
+					tag: 'div',
+					key: `route-${String(depth)}-${currentRoutePath}`,
+					props: {
+						class: 'router-view-content',
+					},
+					children: [result as EffuseChild],
+				});
+
+				lastRoutePath = currentRoutePath;
+				matchedView.value = content;
+				return;
+			}
 
 			const rendered = renderComponent(component, route, props);
 

--- a/packages/router/src/core/router.ts
+++ b/packages/router/src/core/router.ts
@@ -207,6 +207,28 @@ export const createRouter = (options: RouterOptions): RouterInstance => {
 				);
 			}
 
+			// Run per-route beforeEnter guards
+			const beforeEnterGuards = resolved.matched
+				.map((r) => (r as unknown as { beforeEnter?: NavigationGuard }).beforeEnter)
+				.filter((g): g is NavigationGuard => g !== undefined);
+			const beforeEnterResult = yield* runGuards(
+				beforeEnterGuards,
+				resolved,
+				from
+			);
+			if (!NavigationResult.isAllowed(beforeEnterResult)) {
+				if (beforeEnterResult._tag === 'NavigationRedirected') {
+					return yield* navigate(beforeEnterResult.to, opts);
+				}
+				return NavigationFailure.guardCancelled(
+					resolved,
+					from as ResolvedRoute,
+					beforeEnterResult._tag === 'NavigationCancelled'
+						? beforeEnterResult.reason
+						: undefined
+				);
+			}
+
 			const beforeResolveResult = yield* runGuards(
 				guards.beforeResolve,
 				resolved,

--- a/packages/router/src/utils/composables.ts
+++ b/packages/router/src/utils/composables.ts
@@ -23,7 +23,7 @@
  */
 
 import { Predicate } from 'effect';
-import { markRaw, watchEffect } from '@effuse/core';
+import { markRaw, watchEffect, computed } from '@effuse/core';
 import { getGlobalRouter, type RouterInstance } from '../core/router.js';
 import type { Route, RouteLocation } from '../core/route.js';
 import type { NavigationFailure } from '../navigation/errors.js';
@@ -44,19 +44,70 @@ export const useRoute = (): Route => {
 		throw new RouterNotInstalledError({ operation: 'useRoute' });
 	}
 
-	return new Proxy(routeSignal.value, {
-		get(_target, prop, receiver) {
-			return Reflect.get(
-				routeSignal.value,
-				prop,
-				receiver
-			) as Route[keyof Route];
+	// Create stable reactive proxies so accessing .params only subscribes to param changes
+	const path = computed(() => routeSignal.value.path);
+	const fullPath = computed(() => routeSignal.value.fullPath);
+	const params = computed(() => routeSignal.value.params);
+	const query = computed(() => routeSignal.value.query);
+	const hash = computed(() => routeSignal.value.hash);
+	const matched = computed(() => routeSignal.value.matched);
+	const name = computed(() => routeSignal.value.name);
+	const meta = computed(() => routeSignal.value.meta);
+
+	return new Proxy({} as Route, {
+		get(_target, prop) {
+			switch (prop) {
+				case 'path':
+					return path.value;
+				case 'fullPath':
+					return fullPath.value;
+				case 'params':
+					return params.value;
+				case 'query':
+					return query.value;
+				case 'hash':
+					return hash.value;
+				case 'matched':
+					return matched.value;
+				case 'name':
+					return name.value;
+				case 'meta':
+					return meta.value;
+				default:
+					return undefined;
+			}
 		},
-		ownKeys(_target) {
-			return Reflect.ownKeys(routeSignal.value);
+		ownKeys() {
+			return [
+				'path',
+				'fullPath',
+				'params',
+				'query',
+				'hash',
+				'matched',
+				'name',
+				'meta',
+			];
 		},
 		getOwnPropertyDescriptor(_target, prop) {
-			return Reflect.getOwnPropertyDescriptor(routeSignal.value, prop);
+			if (
+				[
+					'path',
+					'fullPath',
+					'params',
+					'query',
+					'hash',
+					'matched',
+					'name',
+					'meta',
+				].includes(prop as string)
+			) {
+				return {
+					enumerable: true,
+					configurable: true,
+				};
+			}
+			return undefined;
 		},
 	});
 };


### PR DESCRIPTION
## Summary

- **#106** — RouterView now detects and resolves lazy route components asynchronously, showing a loading placeholder while the module loads.
- **#107** — useRoute() rewritten with per-property computed() signals so accessing .params only subscribes to param changes, fixing granular reactivity.
- **#109** — beforeEnter per-route guards are now collected from matched routes and run between beforeEach and beforeResolve.

## Tests
- Added beforeEnter guard tests (call, cancel, redirect, execution order).
- Added lazy component preservation/matching tests.
- All 63 router tests pass. TypeScript typecheck passes.
