### PR TITLE
fix(core): isSignalChild, SSR errors, ReactiveProps leak, Suspense globals, Effect.runSync misuse (#120, #121, #122, #123, #124)

### DIFF
--- a/packages/core/src/__tests__/blueprint/reactive-props.test.ts
+++ b/packages/core/src/__tests__/blueprint/reactive-props.test.ts
@@ -62,6 +62,21 @@ describe('createReactiveProps', () => {
 		expect(proxy.b).toBe(3);
 	});
 
+	it('should remove old keys via update', () => {
+		const { proxy, update } = createReactiveProps<{ a: number; b?: number }>({
+			a: 1,
+			b: 2,
+		});
+
+		expect(proxy.a).toBe(1);
+		expect(proxy.b).toBe(2);
+
+		update({ a: 3 });
+		expect(proxy.a).toBe(3);
+		expect(proxy.b).toBeUndefined();
+		expect(Object.keys(proxy)).toEqual(['a']);
+	});
+
 	it('should enumerate keys via Object.keys', () => {
 		const { proxy, update } = createReactiveProps<{ x: number; y?: number }>({ x: 1 });
 

--- a/packages/core/src/__tests__/render/node.test.ts
+++ b/packages/core/src/__tests__/render/node.test.ts
@@ -1,0 +1,34 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isSignalChild, isEffuseNode, CreateElementNode } from '../../render/node.js';
+import { signal } from '../../reactivity/signal.js';
+
+describe('isSignalChild', () => {
+	it('should return true for a signal', () => {
+		const s = signal('hello');
+		expect(isSignalChild(s)).toBe(true);
+	});
+
+	it('should return false for a plain object', () => {
+		expect(isSignalChild({ value: 'hello' })).toBe(false);
+	});
+
+	it('should return false for null', () => {
+		expect(isSignalChild(null)).toBe(false);
+	});
+
+	it('should return false for a string', () => {
+		expect(isSignalChild('hello')).toBe(false);
+	});
+});
+
+describe('isEffuseNode', () => {
+	it('should return false for a plain object', () => {
+		expect(isEffuseNode({})).toBe(false);
+	});
+});

--- a/packages/core/src/blueprint/reactive-props.ts
+++ b/packages/core/src/blueprint/reactive-props.ts
@@ -91,6 +91,12 @@ export const createReactiveProps = <P extends Record<string, unknown>>(
 	});
 
 	const update = (newProps: P): void => {
+		const newKeys = new Set(Object.keys(newProps));
+		for (const key of signals.keys()) {
+			if (!newKeys.has(key)) {
+				signals.delete(key);
+			}
+		}
 		for (const [key, value] of Object.entries(newProps)) {
 			const existing = signals.get(key);
 			if (existing) {

--- a/packages/core/src/render/node.ts
+++ b/packages/core/src/render/node.ts
@@ -130,6 +130,6 @@ export const isSignalChild = (value: unknown): value is Signal<EffuseChild> => {
 	return (
 		Predicate.isObject(value) &&
 		'value' in value &&
-		Predicate.isObject((value as Record<string, unknown>)._subscribers)
+		('_ref' in value || '_dep' in value)
 	);
 };

--- a/packages/core/src/services/dom-renderer/mount.ts
+++ b/packages/core/src/services/dom-renderer/mount.ts
@@ -338,35 +338,19 @@ const mountNode = (
 
 							if (
 								(key === 'value' || key === 'checked') &&
-								Predicate.isFunction(value) &&
+								(Predicate.isFunction(value) || isSignal(value)) &&
 								(element instanceof HTMLInputElement ||
 									element instanceof HTMLTextAreaElement ||
 									element instanceof HTMLSelectElement)
 							) {
-								const result = Effect.runSync(
+								propEffects.push(
 									propService.bindFormControl(
 										element,
-										value as () => string | number | boolean
+										value as
+											| (() => string | number | boolean)
+											| Signal<string | number | boolean>
 									)
 								);
-								bindingCleanups.push(result.cleanup);
-								continue;
-							}
-
-							if (
-								(key === 'value' || key === 'checked') &&
-								isSignal(value) &&
-								(element instanceof HTMLInputElement ||
-									element instanceof HTMLTextAreaElement ||
-									element instanceof HTMLSelectElement)
-							) {
-								const result = Effect.runSync(
-									propService.bindFormControl(
-										element,
-										value as Signal<string | number | boolean>
-									)
-								);
-								bindingCleanups.push(result.cleanup);
 								continue;
 							}
 
@@ -374,30 +358,35 @@ const mountNode = (
 						}
 					}
 
-					for (const propEffect of propEffects) {
-						const result = Effect.runSync(pipe(propEffect, mapEffuseErrors));
-						bindingCleanups.push(result.cleanup);
-					}
-
-					for (const eventEffect of eventEffects) {
-						const result = Effect.runSync(pipe(eventEffect, mapEffuseErrors));
-						bindingCleanups.push(result.cleanup);
-					}
-
-					cleanups.push(() => {
-						for (const fn of bindingCleanups) {
-							fn();
-						}
-					});
+					const allBindingEffects = [
+						...propEffects.map((e) => pipe(e, mapEffuseErrors)),
+						...eventEffects.map((e) => pipe(e, mapEffuseErrors)),
+					];
 
 					return pipe(
-						Effect.all(children.map((c) => mountChild(c, cleanups))),
+						Effect.all(allBindingEffects),
 						Effect.map((results) => {
-							for (const childNode of results.flat()) {
-								element.appendChild(childNode);
+							for (const result of results) {
+								bindingCleanups.push(result.cleanup);
 							}
-							return [element];
-						})
+							cleanups.push(() => {
+								for (const fn of bindingCleanups) {
+									fn();
+								}
+							});
+							return element;
+						}),
+						Effect.flatMap(() =>
+							pipe(
+								Effect.all(children.map((c) => mountChild(c, cleanups))),
+								Effect.map((results) => {
+									for (const childNode of results.flat()) {
+										element.appendChild(childNode);
+									}
+									return [element];
+								})
+							)
+						)
 					);
 				})
 			);

--- a/packages/core/src/ssr/render.ts
+++ b/packages/core/src/ssr/render.ts
@@ -155,8 +155,11 @@ const renderNodeToString = (node: unknown): string => {
 		try {
 			const result = (node as () => unknown)();
 			return renderNodeToString(result);
-		} catch {
-			return '';
+		} catch (err) {
+			if (isSuspendToken(err)) {
+				return '';
+			}
+			throw err;
 		}
 	}
 

--- a/packages/core/src/suspense/Suspense.ts
+++ b/packages/core/src/suspense/Suspense.ts
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import { Predicate, Option } from 'effect';
+import { Predicate } from 'effect';
 import { define } from '../blueprint/index.js';
 import { computed } from '../reactivity/index.js';
 import { watchEffect } from '../effects/index.js';
@@ -57,51 +57,30 @@ export interface SuspenseContext {
 	readonly waitForAll: () => Promise<void>;
 }
 
-export interface SuspenseApi {
-	readonly createBoundary: () => SuspenseContext;
-	readonly getCurrentBoundary: () => Option.Option<SuspenseContext>;
-	readonly pushBoundary: (boundary: SuspenseContext) => void;
-	readonly popBoundary: () => void;
-}
-
 let boundaryIdCounter = 0;
 
 const generateBoundaryId = (prefix: string): string =>
 	`${prefix}${String(++boundaryIdCounter)}`;
 
-const boundaryStack: SuspenseContext[] = [];
+const createBoundary = (): SuspenseContext => {
+	const id = generateBoundaryId(BOUNDARY_ID_PREFIX);
+	const pendingResources = new Map<string, Promise<void>>();
 
-export const suspenseApi: SuspenseApi = {
-	createBoundary: (): SuspenseContext => {
-		const id = generateBoundaryId(BOUNDARY_ID_PREFIX);
-		const pendingResources = new Map<string, Promise<void>>();
-
-		return {
-			id,
-			pendingResources,
-			registerPending: (resourceId: string, promise: Promise<void>) => {
-				pendingResources.set(resourceId, promise);
-			},
-			unregisterPending: (resourceId: string) => {
-				pendingResources.delete(resourceId);
-			},
-			hasPending: () => pendingResources.size > 0,
-			waitForAll: async () => {
-				const promises = Array.from(pendingResources.values());
-				await Promise.all(promises);
-			},
-		};
-	},
-
-	getCurrentBoundary: () => Option.fromNullable(boundaryStack.at(-1)),
-
-	pushBoundary: (boundary: SuspenseContext) => {
-		boundaryStack.push(boundary);
-	},
-
-	popBoundary: () => {
-		boundaryStack.pop();
-	},
+	return {
+		id,
+		pendingResources,
+		registerPending: (resourceId: string, promise: Promise<void>) => {
+			pendingResources.set(resourceId, promise);
+		},
+		unregisterPending: (resourceId: string) => {
+			pendingResources.delete(resourceId);
+		},
+		hasPending: () => pendingResources.size > 0,
+		waitForAll: async () => {
+			const promises = Array.from(pendingResources.values());
+			await Promise.all(promises);
+		},
+	};
 };
 
 export interface SuspenseProps {
@@ -124,7 +103,7 @@ interface SuspenseExposed {
 
 export const Suspense = define<SuspenseProps, SuspenseExposed>({
 	script: ({ props, signal: createSignal }) => {
-		const boundary = suspenseApi.createBoundary();
+		const boundary = createBoundary();
 		const isPending = createSignal(true);
 		const shouldShowFallback = createSignal(true);
 		const resolvedChildren = createSignal<EffuseChild>(null);
@@ -168,7 +147,6 @@ export const Suspense = define<SuspenseProps, SuspenseExposed>({
 			children: EffuseChild | (() => EffuseChild),
 			_fallback: EffuseChild
 		): void => {
-			suspenseApi.pushBoundary(boundary);
 			try {
 				let childToRender = children;
 				if (Array.isArray(children) && children.length === 1) {
@@ -185,8 +163,6 @@ export const Suspense = define<SuspenseProps, SuspenseExposed>({
 				} else {
 					throw error;
 				}
-			} finally {
-				suspenseApi.popBoundary();
 			}
 		};
 


### PR DESCRIPTION
## Summary

- **#120** — `isSignalChild` now checks `_ref`/`_dep` instead of non-existent `_subscribers`, making it actually functional.
- **#121** — `renderNodeToString` now re-throws non-`SuspendToken` errors instead of silently swallowing them.
- **#122** — `ReactiveProps.update()` now removes signals for props that are no longer passed, preventing stale values.
- **#123** — Removed global `boundaryStack` and deprecated `getCurrentBoundary`/`pushBoundary`/`popBoundary`. Boundaries are now local to each Suspense instance, fixing concurrent SSR corruption.
- **#124** — Removed nested `Effect.runSync` calls inside the Element mounting pipeline. All prop/event bindings are now composed into a single `Effect.all` chain.

## Tests
- Added `isSignalChild` tests (true for signals, false for plain objects/strings/null).
- Added `ReactiveProps` key removal test.
- All 1100 core tests pass.
