### PR TITLE
fix(core): context registry isolation, SSR error logging, hydration escaping, context deduplication (#126, #127, #128, #129)

### DIFF
--- a/packages/core/src/__tests__/context/context.test.ts
+++ b/packages/core/src/__tests__/context/context.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { createContext } from '../../context/context.js';
+
+describe('createContext deduplication', () => {
+	it('should return the same context instance for the same id', () => {
+		const ctx1 = createContext({ id: 'test-dedup', defaultValue: 42 });
+		const ctx2 = createContext({ id: 'test-dedup', defaultValue: 99 });
+
+		expect(ctx1).toBe(ctx2);
+		// Should preserve the first default value
+		expect(ctx1.defaultValue).toBe(42);
+	});
+
+	it('should create distinct contexts for different ids', () => {
+		const ctxA = createContext({ id: 'test-a' });
+		const ctxB = createContext({ id: 'test-b' });
+
+		expect(ctxA).not.toBe(ctxB);
+		expect(ctxA.id).toBe('test-a');
+		expect(ctxB.id).toBe('test-b');
+	});
+});

--- a/packages/core/src/__tests__/context/registry.test.ts
+++ b/packages/core/src/__tests__/context/registry.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Option } from 'effect';
+import {
+	runWithContextRegistry,
+	pushContext,
+	popContext,
+	getContext,
+	hasContext,
+	getRegisteredContexts,
+	clearAllContexts,
+} from '../../context/registry.js';
+
+describe('ContextRegistry', () => {
+	beforeEach(() => {
+		clearAllContexts();
+	});
+
+	describe('runWithContextRegistry', () => {
+		it('should isolate context stacks between runs', () => {
+			let valueA: unknown;
+			let valueB: unknown;
+
+			runWithContextRegistry(() => {
+				pushContext('test', 'A');
+				valueA = getContext('test');
+			});
+
+			runWithContextRegistry(() => {
+				pushContext('test', 'B');
+				valueB = getContext('test');
+			});
+
+		expect(Option.isSome(valueA as any)).toBe(true);
+		expect((valueA as any).value).toBe('A');
+		expect(Option.isSome(valueB as any)).toBe(true);
+		expect((valueB as any).value).toBe('B');
+		});
+
+		it('should prevent data leaks between concurrent requests', async () => {
+			const results = await Promise.all(
+				[1, 2, 3].map((i) =>
+					new Promise<string>((resolve) => {
+						runWithContextRegistry(() => {
+							pushContext('requestId', `req-${i}`);
+							// Simulate async work
+							setTimeout(() => {
+								const ctx = getContext('requestId');
+								resolve((ctx as any).value);
+							}, 10);
+						});
+					})
+				)
+			);
+
+			expect(results.sort()).toEqual(['req-1', 'req-2', 'req-3']);
+		});
+
+		it('should return the function result', () => {
+			const result = runWithContextRegistry(() => {
+				pushContext('key', 42);
+				return (getContext('key') as any).value;
+			});
+
+			expect(result).toBe(42);
+		});
+	});
+
+	describe('global registry fallback', () => {
+		it('should use global registry when not inside runWithContextRegistry', () => {
+			pushContext('globalKey', 'globalValue');
+			const ctx = getContext('globalKey');
+			expect(Option.isSome(ctx as any)).toBe(true);
+		expect((ctx as any).value).toBe('globalValue');
+		});
+
+		it('should not leak global state into isolated registries', () => {
+			pushContext('shared', 'global');
+
+			let isolatedValue: unknown;
+			runWithContextRegistry(() => {
+				isolatedValue = getContext('shared');
+			});
+
+			// Isolated registry should not see global value
+			expect(Option.isNone(isolatedValue as any)).toBe(true);
+		});
+	});
+
+	describe('context operations', () => {
+		it('should push and pop contexts in LIFO order', () => {
+			pushContext('stack', 'first');
+			pushContext('stack', 'second');
+
+			expect((getContext('stack') as any).value).toBe('second');
+
+			popContext('stack');
+			expect((getContext('stack') as any).value).toBe('first');
+
+			popContext('stack');
+			expect(hasContext('stack')).toBe(false);
+		});
+
+		it('should return all registered context ids', () => {
+			pushContext('a', 1);
+			pushContext('b', 2);
+
+			const ids = getRegisteredContexts();
+			expect(ids).toContain('a');
+			expect(ids).toContain('b');
+		});
+
+		it('should clear all contexts', () => {
+			pushContext('a', 1);
+			pushContext('b', 2);
+
+			clearAllContexts();
+
+			expect(hasContext('a')).toBe(false);
+			expect(hasContext('b')).toBe(false);
+			expect(getRegisteredContexts()).toEqual([]);
+		});
+	});
+});

--- a/packages/core/src/__tests__/ssr/handler.test.ts
+++ b/packages/core/src/__tests__/ssr/handler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { createHandler, createStreamingHandler, parseQuery, createRequestContext } from '../../ssr/handler.js';
 import { defineLayer } from '../../layers/api/defineLayer.js';
 import { clearGlobalLayerContext } from '../../layers/context.js';
@@ -208,6 +208,92 @@ describe('SSR handler', () => {
 			const query = parseQuery(url);
 
 			expect(query).toEqual({});
+		});
+	});
+
+	describe('error handling', () => {
+		it('should call onError when createHandler throws', async () => {
+			const onError = vi.fn();
+			const handler = createHandler({
+				root: createRoot() as any,
+				layers: [],
+				onError,
+				transform: () => {
+					throw new Error('transform failed');
+				},
+			});
+
+			const request = new Request('http://localhost:3000/');
+			const response = await handler(request);
+
+			expect(response.status).toBe(500);
+			expect(onError).toHaveBeenCalledOnce();
+			expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+			expect(onError.mock.calls[0][0].message).toBe('transform failed');
+			expect(onError.mock.calls[0][1]).toBeInstanceOf(Request);
+		});
+
+		it('should console.error when createHandler throws without onError', async () => {
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+			const handler = createHandler({
+				root: createRoot() as any,
+				layers: [],
+				transform: () => {
+					throw new Error('transform failed');
+				},
+			});
+
+			const request = new Request('http://localhost:3000/');
+			const response = await handler(request);
+
+			expect(response.status).toBe(500);
+			expect(consoleSpy).toHaveBeenCalledOnce();
+			expect(consoleSpy.mock.calls[0][0]).toContain('[effuse-ssr] Render error:');
+			expect(consoleSpy.mock.calls[0][1]).toBeInstanceOf(Error);
+
+			consoleSpy.mockRestore();
+		});
+
+		it('should call onError when createStreamingHandler throws', async () => {
+			const onError = vi.fn();
+			const handler = createStreamingHandler({
+				root: createRoot() as any,
+				layers: [],
+				onError,
+				transform: () => {
+					throw new Error('stream transform failed');
+				},
+			});
+
+			const request = new Request('http://localhost:3000/');
+			const response = await handler(request);
+
+			expect(response.status).toBe(500);
+			expect(onError).toHaveBeenCalledOnce();
+			expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+			expect(onError.mock.calls[0][0].message).toBe('stream transform failed');
+			expect(onError.mock.calls[0][1]).toBeInstanceOf(Request);
+		});
+
+		it('should console.error when createStreamingHandler throws without onError', async () => {
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+			const handler = createStreamingHandler({
+				root: createRoot() as any,
+				layers: [],
+				transform: () => {
+					throw new Error('stream transform failed');
+				},
+			});
+
+			const request = new Request('http://localhost:3000/');
+			const response = await handler(request);
+
+			expect(response.status).toBe(500);
+			expect(consoleSpy).toHaveBeenCalledOnce();
+			expect(consoleSpy.mock.calls[0][0]).toContain('[effuse-ssr] Streaming render error:');
+			expect(consoleSpy.mock.calls[0][1]).toBeInstanceOf(Error);
+
+			consoleSpy.mockRestore();
 		});
 	});
 

--- a/packages/core/src/__tests__/ssr/hydration.test.ts
+++ b/packages/core/src/__tests__/ssr/hydration.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { serializeHydrationData, getHydrationData } from '../../ssr/hydration.js';
+
+describe('serializeHydrationData', () => {
+	it('should escape </script to prevent HTML break-out', () => {
+		const data = {
+			head: {},
+			state: { evil: '</script><script>alert("xss")</script>' },
+			url: '/',
+			timestamp: 0,
+		};
+
+		const html = serializeHydrationData(data);
+		// Extract JSON payload inside the script tag
+		const match = html.match(/<script[^>]*>(.*?)<\/script>/s);
+		expect(match).toBeTruthy();
+		const json = match![1];
+		expect(json).not.toContain('</script>');
+		expect(json).toContain('\\u003c/script');
+	});
+
+	it('should escape <!-- to prevent comment injection', () => {
+		const data = {
+			head: {},
+			state: { evil: '<!-- bad -->' },
+			url: '/',
+			timestamp: 0,
+		};
+
+		const html = serializeHydrationData(data);
+		const match = html.match(/<script[^>]*>(.*?)<\/script>/s);
+		expect(match).toBeTruthy();
+		const json = match![1];
+		expect(json).not.toContain('<!--');
+		expect(json).toContain('\\u003c!--');
+	});
+
+	it('should escape <!CDATA[ to prevent CDATA injection', () => {
+		const data = {
+			head: {},
+			state: { evil: '<!CDATA[ something ]]>' },
+			url: '/',
+			timestamp: 0,
+		};
+
+		const html = serializeHydrationData(data);
+		const match = html.match(/<script[^>]*>(.*?)<\/script>/s);
+		expect(match).toBeTruthy();
+		const json = match![1];
+		expect(json).not.toContain('<!CDATA[');
+		expect(json).toContain('\\u003c!CDATA[');
+	});
+
+	it('should escape any < character comprehensively', () => {
+		const data = {
+			head: {},
+			state: { evil: '<svg onload=alert(1)>' },
+			url: '/',
+			timestamp: 0,
+		};
+
+		const html = serializeHydrationData(data);
+		const match = html.match(/<script[^>]*>(.*?)<\/script>/s);
+		expect(match).toBeTruthy();
+		const json = match![1];
+		expect(json).not.toContain('<svg');
+		expect(json).toContain('\\u003csvg');
+	});
+
+	it('should produce parseable JSON after unescaping', () => {
+		const data = {
+			head: { title: 'Test' },
+			state: { foo: 'bar', num: 42 },
+			url: '/test',
+			timestamp: 12345,
+		};
+
+		const html = serializeHydrationData(data);
+		// Extract JSON from script tag
+		const match = html.match(/<script[^>]*>(.*?)<\/script>/s);
+		expect(match).toBeTruthy();
+		const escaped = match![1];
+		// Reverse the escaping
+		const json = escaped.replace(/\\u003c/g, '<');
+		const parsed = JSON.parse(json);
+		expect(parsed).toEqual(data);
+	});
+});
+
+describe('getHydrationData', () => {
+	it('should return null when document is undefined', () => {
+		expect(getHydrationData()).toBeNull();
+	});
+});

--- a/packages/core/src/context/context.ts
+++ b/packages/core/src/context/context.ts
@@ -63,7 +63,7 @@ export function createContext<T>(options: ContextOptions<T>): EffuseContext<T> {
 	const { id, defaultValue, displayName = id } = options;
 
 	const existing = createdContexts.get(id);
-	if (existing && typeof window !== 'undefined') {
+	if (existing) {
 		return existing as EffuseContext<T>;
 	}
 

--- a/packages/core/src/context/registry.ts
+++ b/packages/core/src/context/registry.ts
@@ -23,10 +23,11 @@
  */
 
 import { Effect, Ref, Option, pipe, HashMap } from 'effect';
+import { AsyncLocalStorage } from 'node:async_hooks';
 
 type ContextStack = HashMap.HashMap<string, readonly unknown[]>;
 
-interface ContextRegistryService {
+export interface ContextRegistryService {
 	readonly push: (id: string, value: unknown) => Effect.Effect<void>;
 	readonly pop: (id: string) => Effect.Effect<void>;
 	readonly get: <T>(id: string) => Effect.Effect<Option.Option<T>>;
@@ -109,36 +110,57 @@ const makeContextRegistry = Effect.gen(function* () {
 
 export { makeContextRegistry };
 
+const registryStorage = new AsyncLocalStorage<ContextRegistryService>();
+
 let globalRegistry: ContextRegistryService | null = null;
 
-const initializeRegistry = (): ContextRegistryService => {
+const getGlobalRegistry = (): ContextRegistryService => {
 	if (!globalRegistry) {
 		globalRegistry = Effect.runSync(makeContextRegistry);
 	}
 	return globalRegistry;
 };
 
+const getRegistry = (): ContextRegistryService => {
+	return registryStorage.getStore() ?? getGlobalRegistry();
+};
+
+/**
+ * Run a function with an isolated context registry.
+ * Use this in SSR to ensure each request gets its own registry,
+ * preventing data leaks between concurrent requests.
+ */
+export const runWithContextRegistry = <T>(fn: () => T): T => {
+	const registry = Effect.runSync(makeContextRegistry);
+	return registryStorage.run(registry, fn);
+};
+
 export const pushContext = (id: string, value: unknown): void => {
-	Effect.runSync(initializeRegistry().push(id, value));
+	Effect.runSync(getRegistry().push(id, value));
 };
 
 export const popContext = (id: string): void => {
-	Effect.runSync(initializeRegistry().pop(id));
+	Effect.runSync(getRegistry().pop(id));
 };
 
 export const getContext = <T>(id: string): Option.Option<T> => {
-	return Effect.runSync(initializeRegistry().get<T>(id));
+	return Effect.runSync(getRegistry().get<T>(id));
 };
 
 export const hasContext = (id: string): boolean => {
-	return Effect.runSync(initializeRegistry().has(id));
+	return Effect.runSync(getRegistry().has(id));
 };
 
 export const getRegisteredContexts = (): readonly string[] => {
-	return Effect.runSync(initializeRegistry().getAll());
+	return Effect.runSync(getRegistry().getAll());
 };
 
 export const clearAllContexts = (): void => {
-	Effect.runSync(initializeRegistry().clear());
-	globalRegistry = null;
+	Effect.runSync(getRegistry().clear());
+	// Only reset globalRegistry if we're using the global one
+	if (!registryStorage.getStore()) {
+		globalRegistry = null;
+	}
 };
+
+

--- a/packages/core/src/ssr/handler.ts
+++ b/packages/core/src/ssr/handler.ts
@@ -39,6 +39,8 @@ export interface HandlerConfig {
 	cacheMaxAge?: number;
 	/** Cache-Control s-maxage for CDN caching. Defaults to undefined (not set). */
 	cacheSMaxAge?: number;
+	/** Optional error handler for logging/monitoring. Called before returning 500. */
+	onError?: (error: unknown, request: Request) => void;
 }
 
 export const createHandler = (config: HandlerConfig) => {
@@ -47,8 +49,9 @@ export const createHandler = (config: HandlerConfig) => {
 		.configure(config.options ?? {});
 
 	return async (request: Request): Promise<Response> => {
+		let req = request;
 		try {
-			const req = config.transform ? config.transform(request) : request;
+			req = config.transform ? config.transform(request) : request;
 
 			const url = new URL(req.url);
 			const pathname = url.pathname;
@@ -90,7 +93,13 @@ export const createHandler = (config: HandlerConfig) => {
 					'X-Content-Type-Options': 'nosniff',
 				},
 			});
-		} catch {
+		} catch (error) {
+			if (config.onError) {
+				config.onError(error, req);
+			} else {
+				// eslint-disable-next-line no-console
+				console.error('[effuse-ssr] Render error:', error);
+			}
 			return new Response(
 				`<!DOCTYPE html><html><head><title>Error</title></head><body><h1>Server Error</h1></body></html>`,
 				{
@@ -115,8 +124,9 @@ export const createStreamingHandler = (config: HandlerConfig) => {
 		.configure(config.options ?? {});
 
 	return async (request: Request): Promise<Response> => {
+		let req = request;
 		try {
-			const req = config.transform ? config.transform(request) : request;
+			req = config.transform ? config.transform(request) : request;
 
 			const url = new URL(req.url);
 			const pathname = url.pathname;
@@ -135,7 +145,13 @@ export const createStreamingHandler = (config: HandlerConfig) => {
 					'X-Content-Type-Options': 'nosniff',
 				},
 			});
-		} catch {
+		} catch (error) {
+			if (config.onError) {
+				config.onError(error, req);
+			} else {
+				// eslint-disable-next-line no-console
+				console.error('[effuse-ssr] Streaming render error:', error);
+			}
 			return new Response(
 				`<!DOCTYPE html><html><head><title>Error</title></head><body><h1>Server Error</h1></body></html>`,
 				{

--- a/packages/core/src/ssr/hydration.ts
+++ b/packages/core/src/ssr/hydration.ts
@@ -42,7 +42,9 @@ export interface HydrationData {
  */
 export const serializeHydrationData = (data: HydrationData): string => {
 	const json = JSON.stringify(data);
-	const escaped = json.replace(/<\/script/gi, '<\\/script');
+	// Escape '<' to \u003c to prevent ANY HTML break-out sequences
+	// (</script, <!--, <!CDATA[, etc.) from being interpreted by the parser.
+	const escaped = json.replace(/</g, '\\u003c');
 	return `<script id="${HYDRATION_SCRIPT_ID}" type="application/json">${escaped}</script>`;
 };
 


### PR DESCRIPTION
## Summary

Fixes critical security and data integrity issues in `packages/core/`.

### Changes
- **#126** — Replaced global singleton `globalRegistry` with `AsyncLocalStorage`-scoped registry and `runWithContextRegistry()` helper to prevent SSR request data leaks.
- **#127** — Added `onError` callback + `console.error` fallback to `createHandler` and `createStreamingHandler`. Fixed `req` scoping bug so errors in `transform` are properly reported.
- **#128** — Replaced partial `</script` escaping with comprehensive `<` → `\u003c` escape to prevent all HTML break-out vectors (XSS).
- **#129** — Removed broken `typeof window !== 'undefined'` check from `createContext()` deduplication, which was always false in SSR and caused duplicate contexts.

### Tests
- Added `registry.test.ts` for AsyncLocalStorage isolation and concurrent safety.
- Added `context.test.ts` for context deduplication.
- Added `hydration.test.ts` for comprehensive escaping of `<`, `</script`, `<!--`, `<!CDATA[`.
- Extended `handler.test.ts` with error handling coverage for both handler variants.