### PR TITLE
fix(core): AsyncBoundary error passing, For stale closure, emit isolation, builder typed errors, form input types (#130, #131, #132, #133, #134)

### DIFF
--- a/packages/core/src/__tests__/components/async-boundary.test.ts
+++ b/packages/core/src/__tests__/components/async-boundary.test.ts
@@ -107,6 +107,22 @@ describe('AsyncBoundary', () => {
 			expect(result).toBe('error-result');
 		});
 
+		it('should pass the error to onError handler when provided', () => {
+			const testError = new Error('something went wrong');
+			const result = matchAsyncStatus(
+				'error',
+				{
+					onIdle: () => null,
+					onLoading: () => null,
+					onSuccess: () => null,
+					onError: (error) => error,
+				},
+				testError
+			);
+
+			expect(result).toBe(testError);
+		});
+
 		it('should be exhaustive for all statuses', () => {
 			const statuses: AsyncStatus[] = ['idle', 'loading', 'success', 'error'];
 			const results: string[] = [];

--- a/packages/core/src/__tests__/components/for-dynamic.test.ts
+++ b/packages/core/src/__tests__/components/for-dynamic.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { For } from '../../components/For.js';
+import { signal } from '../../reactivity/signal.js';
+import { isSignal } from '../../reactivity/index.js';
+import { EFFUSE_NODE } from '../../constants.js';
+
+describe('For.Dynamic', () => {
+	it('should give each item its own index signal with the correct value', () => {
+		const items = signal(['a', 'b', 'c']);
+		const capturedIndices: number[] = [];
+
+		const node = For.Dynamic(items, (item, indexSignal) => {
+			capturedIndices.push(indexSignal.value);
+			return {
+				[EFFUSE_NODE]: true,
+				_tag: 'Text',
+				text: `${item}:${indexSignal.value}`,
+			} as any;
+		});
+
+		// Trigger children getter
+		const children = (node as any).children;
+
+		expect(children).toHaveLength(3);
+		expect(capturedIndices).toEqual([0, 1, 2]);
+	});
+
+	it('should update index signals when the list changes', () => {
+		const items = signal(['x', 'y']);
+		const indexSignals: any[] = [];
+
+		const node = For.Dynamic(items, (item, indexSignal) => {
+			indexSignals.push(indexSignal);
+			return {
+				[EFFUSE_NODE]: true,
+				_tag: 'Text',
+				text: item,
+			} as any;
+		});
+
+		// First access
+		void (node as any).children;
+		expect(indexSignals).toHaveLength(2);
+		expect(indexSignals[0].value).toBe(0);
+		expect(indexSignals[1].value).toBe(1);
+
+		// Add an item
+		items.value = ['x', 'y', 'z'];
+		indexSignals.length = 0;
+		void (node as any).children;
+		expect(indexSignals).toHaveLength(3);
+		expect(indexSignals[0].value).toBe(0);
+		expect(indexSignals[1].value).toBe(1);
+		expect(indexSignals[2].value).toBe(2);
+	});
+});

--- a/packages/core/src/__tests__/emit/service.test.ts
+++ b/packages/core/src/__tests__/emit/service.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getEmitService } from '../../emit/services/service.js';
+
+describe('EmitService handler isolation', () => {
+	it('should call all handlers even if one throws', () => {
+		const service = getEmitService();
+		const ctx = service.createContext<Record<string, unknown>>();
+
+		const goodHandler = vi.fn();
+		const badHandler = vi.fn(() => {
+			throw new Error('bad handler');
+		});
+		const anotherGoodHandler = vi.fn();
+
+		service.registerHandler(ctx, 'test-event', goodHandler);
+		service.registerHandler(ctx, 'test-event', badHandler);
+		service.registerHandler(ctx, 'test-event', anotherGoodHandler);
+
+		// Should not throw
+		expect(() => service.emit(ctx, 'test-event', { foo: 'bar' })).not.toThrow();
+
+		expect(goodHandler).toHaveBeenCalledOnce();
+		expect(badHandler).toHaveBeenCalledOnce();
+		expect(anotherGoodHandler).toHaveBeenCalledOnce();
+	});
+
+	it('should still update signal even if a handler throws', () => {
+		const service = getEmitService();
+		const ctx = service.createContext<Record<string, unknown>>();
+
+		const badHandler = vi.fn(() => {
+			throw new Error('bad');
+		});
+
+		service.registerHandler(ctx, 'test-event', badHandler);
+		const sig = service.getSignal(ctx, 'test-event');
+
+		expect(() => service.emit(ctx, 'test-event', 42)).not.toThrow();
+		expect(sig.value).toBe(42);
+	});
+});

--- a/packages/core/src/__tests__/form/useForm.test.ts
+++ b/packages/core/src/__tests__/form/useForm.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { useForm } from '../../form/useForm.js';
+import { signal } from '../../reactivity/signal.js';
+
+describe('useForm bind input types', () => {
+	it('should handle checkbox inputs', () => {
+		const form = useForm({
+			initial: { agree: signal(false) },
+		});
+		const binding = form.bind('agree');
+
+		const checkbox = {
+			tagName: 'INPUT',
+			type: 'checkbox',
+			checked: true,
+		} as unknown as HTMLInputElement;
+
+		binding.onInput({ target: checkbox } as unknown as Event);
+		expect(form.fields.agree.value).toBe(true);
+	});
+
+	it('should handle radio inputs', () => {
+		const form = useForm({
+			initial: { color: signal('red') },
+		});
+		const binding = form.bind('color');
+
+		const radio = {
+			tagName: 'INPUT',
+			type: 'radio',
+			value: 'blue',
+			checked: true,
+		} as unknown as HTMLInputElement;
+
+		binding.onInput({ target: radio } as unknown as Event);
+		expect(form.fields.color.value).toBe('blue');
+	});
+
+	it('should handle number inputs', () => {
+		const form = useForm({
+			initial: { age: signal(0) },
+		});
+		const binding = form.bind('age');
+
+		const numberInput = {
+			tagName: 'INPUT',
+			type: 'number',
+			value: '25',
+			get valueAsNumber() {
+				return Number(this.value);
+			},
+		} as unknown as HTMLInputElement;
+
+		binding.onInput({ target: numberInput } as unknown as Event);
+		expect(form.fields.age.value).toBe(25);
+	});
+
+	it('should handle range inputs', () => {
+		const form = useForm({
+			initial: { volume: signal(0) },
+		});
+		const binding = form.bind('volume');
+
+		const rangeInput = {
+			tagName: 'INPUT',
+			type: 'range',
+			value: '75',
+			get valueAsNumber() {
+				return Number(this.value);
+			},
+		} as unknown as HTMLInputElement;
+
+		binding.onInput({ target: rangeInput } as unknown as Event);
+		expect(form.fields.volume.value).toBe(75);
+	});
+
+	it('should handle select inputs', () => {
+		const form = useForm({
+			initial: { country: signal('') },
+		});
+		const binding = form.bind('country');
+
+		const select = {
+			tagName: 'SELECT',
+			multiple: false,
+			value: 'uk',
+			selectedOptions: [{ value: 'uk' }],
+		} as unknown as HTMLSelectElement;
+
+		binding.onInput({ target: select } as unknown as Event);
+		expect(form.fields.country.value).toBe('uk');
+	});
+
+	it('should handle multi-select inputs', () => {
+		const form = useForm({
+			initial: { tags: signal([] as string[]) },
+		});
+		const binding = form.bind('tags');
+
+		const select = {
+			tagName: 'SELECT',
+			multiple: true,
+			selectedOptions: [{ value: 'a' }, { value: 'b' }],
+		} as unknown as HTMLSelectElement;
+
+		binding.onInput({ target: select } as unknown as Event);
+		expect(form.fields.tags.value).toEqual(['a', 'b']);
+	});
+
+	it('should fall back to text value for unknown input types', () => {
+		const form = useForm({
+			initial: { name: signal('') },
+		});
+		const binding = form.bind('name');
+
+		const input = {
+			tagName: 'INPUT',
+			type: 'text',
+			value: 'Alice',
+		} as unknown as HTMLInputElement;
+
+		binding.onInput({ target: input } as unknown as Event);
+		expect(form.fields.name.value).toBe('Alice');
+	});
+});

--- a/packages/core/src/__tests__/layers/builder.test.ts
+++ b/packages/core/src/__tests__/layers/builder.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { Effect, Exit, Cause, Option, Layer } from 'effect';
+import { buildLayerEffect } from '../../layers/internal/builder.js';
+import { PropsService } from '../../layers/services/PropsService.js';
+import { RegistryService } from '../../layers/services/RegistryService.js';
+import { TracingServiceLive } from '../../layers/tracing/index.js';
+import { LayerSetupError } from '../../layers/errors.js';
+import type { AnyResolvedLayer } from '../../layers/types.js';
+
+const testLayer = Layer.mergeAll(
+	PropsService.Default,
+	RegistryService.Default,
+	TracingServiceLive({})
+);
+
+const runTest = <A, E>(effect: Effect.Effect<A, E, any>) =>
+	Effect.runPromiseExit(Effect.provide(effect, testLayer));
+
+describe('buildLayerEffect', () => {
+	it('should fail with LayerSetupError when onMount throws', async () => {
+		const layer: AnyResolvedLayer = {
+			name: 'failing-mount',
+			onMount: () => {
+				throw new Error('mount boom');
+			},
+		} as unknown as AnyResolvedLayer;
+
+		const result = await runTest(buildLayerEffect(layer, []));
+
+		expect(Exit.isFailure(result)).toBe(true);
+		if (Exit.isFailure(result)) {
+			const errorOpt = Cause.failureOption(result.cause);
+			expect(Option.isSome(errorOpt)).toBe(true);
+			if (Option.isSome(errorOpt)) {
+				expect(errorOpt.value).toBeInstanceOf(LayerSetupError);
+				expect((errorOpt.value as LayerSetupError).layerName).toBe('failing-mount');
+				expect((errorOpt.value as LayerSetupError).phase).toBe('onMount');
+			}
+		}
+	});
+
+	it('should fail with LayerSetupError when setup throws', async () => {
+		const layer: AnyResolvedLayer = {
+			name: 'failing-setup',
+			setup: () => {
+				throw new Error('setup boom');
+			},
+		} as unknown as AnyResolvedLayer;
+
+		const result = await runTest(buildLayerEffect(layer, []));
+
+		expect(Exit.isFailure(result)).toBe(true);
+		if (Exit.isFailure(result)) {
+			const errorOpt = Cause.failureOption(result.cause);
+			expect(Option.isSome(errorOpt)).toBe(true);
+			if (Option.isSome(errorOpt)) {
+				expect(errorOpt.value).toBeInstanceOf(LayerSetupError);
+				expect((errorOpt.value as LayerSetupError).layerName).toBe('failing-setup');
+				expect((errorOpt.value as LayerSetupError).phase).toBe('setup');
+			}
+		}
+	});
+});

--- a/packages/core/src/components/AsyncBoundary.ts
+++ b/packages/core/src/components/AsyncBoundary.ts
@@ -68,7 +68,8 @@ export const matchAsyncStatus = <R>(
 		onLoading: () => R;
 		onSuccess: () => R;
 		onError: (error: unknown) => R;
-	}
+	},
+	error?: unknown
 ): R => {
 	switch (status) {
 		case 'idle':
@@ -78,7 +79,7 @@ export const matchAsyncStatus = <R>(
 		case 'success':
 			return handlers.onSuccess();
 		case 'error':
-			return handlers.onError(undefined);
+			return handlers.onError(error);
 	}
 };
 

--- a/packages/core/src/components/For.ts
+++ b/packages/core/src/components/For.ts
@@ -237,12 +237,10 @@ const createDynamic = <T>(
 	Object.defineProperty(node, 'children', {
 		get() {
 			const items = sig.value;
-			return items.map((item, i) =>
-				render(
-					item,
-					computed(() => i)
-				)
-			);
+			return items.map((item, i) => {
+				const indexSignal = signal(i);
+				return render(item, indexSignal);
+			});
 		},
 	});
 

--- a/packages/core/src/emit/services/service.ts
+++ b/packages/core/src/emit/services/service.ts
@@ -87,7 +87,12 @@ const defaultService: EmitServiceApi = {
 			const handlers = ctx.handlers.get(event);
 			if (handlers) {
 				for (const handler of handlers) {
-					handler(payload);
+					try {
+						handler(payload);
+					} catch {
+						// Isolate handler errors so one throwing handler
+						// doesn't skip all subsequent ones.
+					}
 				}
 			}
 

--- a/packages/core/src/form/useForm.ts
+++ b/packages/core/src/form/useForm.ts
@@ -179,8 +179,43 @@ export function useForm<T extends Record<string, unknown>>(
 				return fieldSignal.value;
 			},
 			onInput: (e: Event) => {
-				const target = e.target as HTMLInputElement;
-				fieldSignal.value = target.value as T[K];
+				const target = e.target as HTMLInputElement | HTMLSelectElement;
+				const tag = target.tagName.toLowerCase();
+
+				if (tag === 'select') {
+					const select = target as HTMLSelectElement;
+					if (select.multiple) {
+						const values = Array.from(select.selectedOptions).map(
+							(opt) => opt.value
+						);
+						fieldSignal.value = values as T[K];
+					} else {
+						fieldSignal.value = select.value as T[K];
+					}
+					return;
+				}
+
+				const input = target as HTMLInputElement;
+				const type = input.type;
+
+				if (type === 'checkbox') {
+					fieldSignal.value = input.checked as T[K];
+				} else if (type === 'radio') {
+					if (input.checked) {
+						fieldSignal.value = input.value as T[K];
+					}
+				} else if (type === 'file') {
+					if (input.multiple) {
+						fieldSignal.value = Array.from(input.files ?? []) as T[K];
+					} else {
+						fieldSignal.value = (input.files?.[0] ?? null) as T[K];
+					}
+				} else if (type === 'number' || type === 'range') {
+					const num = input.valueAsNumber;
+					fieldSignal.value = (Number.isNaN(num) ? 0 : num) as T[K];
+				} else {
+					fieldSignal.value = input.value as T[K];
+				}
 			},
 			onBlur: () => {
 				touchedSignal.value = true;

--- a/packages/core/src/layers/errors.ts
+++ b/packages/core/src/layers/errors.ts
@@ -97,6 +97,16 @@ export class RouterNotConfiguredError extends Data.TaggedError(
 	}
 }
 
+export class LayerSetupError extends Data.TaggedError('LayerSetupError')<{
+	readonly layerName: string;
+	readonly phase: 'onMount' | 'setup' | 'onReady';
+	readonly cause: unknown;
+}> {
+	get message(): string {
+		return `[Effuse] Layer "${this.layerName}" failed during ${this.phase}: ${String(this.cause)}`;
+	}
+}
+
 export type LayerError =
 	| LayerNotFoundError
 	| LayerRuntimeNotReadyError
@@ -104,4 +114,5 @@ export type LayerError =
 	| ServiceNotFoundError
 	| DependencyNotFoundError
 	| CircularDependencyError
-	| RouterNotConfiguredError;
+	| RouterNotConfiguredError
+	| LayerSetupError;

--- a/packages/core/src/layers/internal/builder.ts
+++ b/packages/core/src/layers/internal/builder.ts
@@ -37,7 +37,7 @@ import {
 	type LayerRegistry,
 } from '../services/RegistryService.js';
 import type { Component } from '../../render/node.js';
-import { DependencyNotFoundError } from '../errors.js';
+import { DependencyNotFoundError, LayerSetupError } from '../errors.js';
 import {
 	withLayerSpan,
 	type TracingService,
@@ -150,7 +150,11 @@ export const buildLayerEffect = (
 					try: () => Promise.resolve(onMountFn(ctx)),
 					catch: (error: unknown) => {
 						handleError(error);
-						return error;
+						return new LayerSetupError({
+							layerName: layer.name,
+							phase: 'onMount',
+							cause: error,
+						});
 					},
 				});
 			}
@@ -162,7 +166,11 @@ export const buildLayerEffect = (
 					try: () => Promise.resolve(setupFn(ctx)),
 					catch: (error: unknown) => {
 						handleError(error);
-						return error;
+						return new LayerSetupError({
+							layerName: layer.name,
+							phase: 'setup',
+							cause: error,
+						});
 					},
 				});
 
@@ -271,10 +279,15 @@ export const buildAllLayersEffect = (
 
 		if (onReadyCallbacks.length > 0) {
 			yield* Effect.all(
-				onReadyCallbacks.map((cb) =>
+				onReadyCallbacks.map((cb, index) =>
 					Effect.tryPromise({
 						try: () => Promise.resolve(cb()),
-						catch: () => undefined,
+						catch: (error: unknown) =>
+							new LayerSetupError({
+								layerName: results[index]?.layer.name ?? 'unknown',
+								phase: 'onReady',
+								cause: error,
+							}),
 					})
 				),
 				{ concurrency: 'unbounded' }


### PR DESCRIPTION
## Summary

Fixes bugs and improves error handling across `packages/core/`.

### Changes
- **#130** — `matchAsyncStatus` now accepts an optional `error` parameter and passes it to `onError`, instead of discarding it with `undefined`.
- **#131** — Fixed stale closure in `For.Dynamic` by replacing `computed(() => i)` with `signal(i)`, ensuring each item gets its own stable index signal.
- **#132** — Wrapped individual emit handler calls in `try/catch` so one throwing handler no longer skips all subsequent handlers.
- **#133** — Added `LayerSetupError` typed error and replaced raw `error` returns in `Effect.tryPromise` catch blocks with properly tagged errors. Fixed `onReady` error handling to also use typed errors.
- **#134** — `useForm.bind()` now handles checkbox, radio, number, range, file, select, and select-multiple inputs instead of assuming all inputs are text fields.

### Tests
- Added `for-dynamic.test.ts` for index signal correctness.
- Added `service.test.ts` for emit handler isolation.
- Added `useForm.test.ts` for multi-input type binding.
- Added `builder.test.ts` for `LayerSetupError` propagation.
- Extended `async-boundary.test.ts` with error parameter coverage.