### PR TITLE
feat(query): production invalidation architecture — mark stale, prefix matching, imperative cache API (#144)

### DIFF
--- a/packages/query/src/client/client.test.ts
+++ b/packages/query/src/client/client.test.ts
@@ -73,7 +73,7 @@ describe('QueryClient Integration', () => {
 		expect(client.get(key)?.data).toBe('original');
 	});
 
-	it('should invalidate queries matching a pattern', async () => {
+	it('should invalidate queries matching a pattern without deleting', async () => {
 		const client = createQueryClient();
 
 		client.set(['todos', 1], {
@@ -97,14 +97,70 @@ describe('QueryClient Integration', () => {
 
 		await Effect.runPromise(client.invalidateQueries(['todos']));
 
-		expect(client.has(['todos', 1])).toBe(false);
-		expect(client.has(['todos', 2])).toBe(false);
+		expect(client.has(['todos', 1])).toBe(true);
+		expect(client.get(['todos', 1])?.isInvalidated).toBe(true);
+		expect(client.has(['todos', 2])).toBe(true);
+		expect(client.get(['todos', 2])?.isInvalidated).toBe(true);
 		expect(client.has(['users', 1])).toBe(true);
+		expect(client.get(['users', 1])?.isInvalidated).toBeFalsy();
 	});
 
 	it('should get global query client singleton', () => {
 		const client1 = getGlobalQueryClient();
 		const client2 = getGlobalQueryClient();
 		expect(client1).toBe(client2);
+	});
+
+	describe('imperative cache API', () => {
+		it('setQueryData should write data directly', () => {
+			const client = createQueryClient();
+			const key = ['post', 1];
+
+			client.setQueryData(key, { title: 'Hello' });
+			expect(client.getQueryData(key)).toEqual({ title: 'Hello' });
+			expect(client.getQueryState(key)?.status).toBe('success');
+		});
+
+		it('setQueryData should support updater function', () => {
+			const client = createQueryClient();
+			const key = ['counter'];
+
+			client.setQueryData(key, 0);
+			client.setQueryData(key, (old) => (old ?? 0) + 1);
+			expect(client.getQueryData(key)).toBe(1);
+		});
+
+		it('setQueryData should preserve fetchCount', () => {
+			const client = createQueryClient();
+			const key = ['item'];
+
+			client.set(key, {
+				data: 'a',
+				status: 'success',
+				dataUpdatedAt: Date.now(),
+				fetchCount: 5,
+			});
+
+			client.setQueryData(key, 'b');
+			expect(client.getQueryState(key)?.fetchCount).toBe(5);
+		});
+
+		it('getQueryData should return undefined for missing key', () => {
+			const client = createQueryClient();
+			expect(client.getQueryData(['missing'])).toBeUndefined();
+		});
+
+		it('removeQueries should delete matching entries by prefix', () => {
+			const client = createQueryClient();
+			client.setQueryData(['todos', 1], 'a');
+			client.setQueryData(['todos', 2], 'b');
+			client.setQueryData(['users', 1], 'c');
+
+			client.removeQueries(['todos']);
+
+			expect(client.has(['todos', 1])).toBe(false);
+			expect(client.has(['todos', 2])).toBe(false);
+			expect(client.has(['users', 1])).toBe(true);
+		});
 	});
 });

--- a/packages/query/src/client/client.ts
+++ b/packages/query/src/client/client.ts
@@ -42,6 +42,7 @@ import {
 	type QueryCacheInternals,
 	type QueryHandlerDeps,
 } from '../handlers/index.js';
+import { partialMatchKey } from '../utils/index.js';
 
 const serializeKey = (key: QueryKey): string => JSON.stringify(key);
 
@@ -71,6 +72,20 @@ export interface QueryClientApi {
 		data: T
 	) => CacheEntry<T> | undefined;
 	readonly rollback: <T>(key: QueryKey, snapshot: CacheEntry<T>) => void;
+	/**
+	 * Directly set query data in the cache.
+	 * `updater` can be the new data or a function receiving the old data.
+	 */
+	readonly setQueryData: <T>(
+		key: QueryKey,
+		updater: T | ((old: T | undefined) => T)
+	) => CacheEntry<T> | undefined;
+	/** Read only the data for a query key. */
+	readonly getQueryData: <T>(key: QueryKey) => T | undefined;
+	/** Read the full cache entry (state) for a query key. */
+	readonly getQueryState: <T>(key: QueryKey) => CacheEntry<T> | undefined;
+	/** Remove queries matching a prefix pattern. */
+	readonly removeQueries: (pattern: QueryKey) => void;
 }
 
 export class QueryClient extends Context.Tag('effuse/query/QueryClient')<
@@ -222,6 +237,49 @@ const createQueryClientImpl = (): QueryClientApi => {
 		rollback: <T>(key: QueryKey, snapshot: CacheEntry<T>): void => {
 			const keyStr = serializeKey(key);
 			setEntry(deps, { keyStr, entry: snapshot });
+		},
+
+		setQueryData: <T>(
+			key: QueryKey,
+			updater: T | ((old: T | undefined) => T)
+		): CacheEntry<T> | undefined => {
+			const keyStr = serializeKey(key);
+			const existing = getEntry<T>(deps, { keyStr });
+			const prevData = existing?.data;
+			const nextData =
+				typeof updater === 'function'
+					? (updater as (old: T | undefined) => T)(prevData)
+					: updater;
+
+			const entry: CacheEntry<T> = {
+				data: nextData,
+				dataUpdatedAt: Date.now(),
+				status: 'success',
+				fetchCount: existing?.fetchCount ?? 0,
+				meta: existing?.meta,
+			};
+
+			setEntry(deps, { keyStr, entry });
+			return entry;
+		},
+
+		getQueryData: <T>(key: QueryKey): T | undefined => {
+			const keyStr = serializeKey(key);
+			return getEntry<T>(deps, { keyStr })?.data;
+		},
+
+		getQueryState: <T>(key: QueryKey): CacheEntry<T> | undefined => {
+			const keyStr = serializeKey(key);
+			return getEntry<T>(deps, { keyStr });
+		},
+
+		removeQueries: (pattern: QueryKey): void => {
+			for (const keyStr of deps.internals.cache.keys()) {
+				const key = parseKey(keyStr);
+				if (partialMatchKey(key, pattern)) {
+					removeEntry(deps, { keyStr });
+				}
+			}
 		},
 	};
 };

--- a/packages/query/src/client/types.ts
+++ b/packages/query/src/client/types.ts
@@ -34,6 +34,12 @@ export interface CacheEntry<T = unknown> {
 	readonly status: QueryStatus;
 	readonly error?: unknown;
 	readonly fetchCount: number;
+	/** Marked stale by invalidateQueries; overrides staleTime. */
+	readonly isInvalidated?: boolean;
+	/** Timestamp when the error was last set. */
+	readonly errorUpdatedAt?: number;
+	/** Arbitrary metadata attached to the query. */
+	readonly meta?: unknown;
 }
 
 export interface QueryOptions<T = unknown> {

--- a/packages/query/src/handlers/cache.ts
+++ b/packages/query/src/handlers/cache.ts
@@ -122,6 +122,7 @@ export const isStale = (
 ): boolean => {
 	const entry = deps.internals.cache.get(input.keyStr);
 	if (!entry) return true;
+	if (entry.isInvalidated) return true;
 	const threshold = staleTime ?? deps.config.staleTimeMs;
 	return Date.now() - entry.dataUpdatedAt > threshold;
 };

--- a/packages/query/src/handlers/invalidation.test.ts
+++ b/packages/query/src/handlers/invalidation.test.ts
@@ -36,11 +36,13 @@ describe('invalidation handlers', () => {
 	});
 
 	describe('invalidateKey', () => {
-		it('should remove entry for exact key', async () => {
+		it('should mark entry as invalidated without removing', async () => {
 			const deps = createMockDeps();
 			deps.internals.cache.set('["users",1]', createEntry({ id: 1 }));
 			await Effect.runPromise(invalidateKey(deps, '["users",1]'));
-			expect(deps.internals.cache.has('["users",1]')).toBe(false);
+			expect(deps.internals.cache.has('["users",1]')).toBe(true);
+			const entry = deps.internals.cache.get('["users",1]');
+			expect(entry?.isInvalidated).toBe(true);
 		});
 
 		it('should notify subscribers', async () => {
@@ -59,30 +61,30 @@ describe('invalidation handlers', () => {
 			).resolves.not.toThrow();
 		});
 
-		it('should clear GC timer when invalidating', async () => {
+		it('should reset GC timer when invalidating', async () => {
 			vi.useFakeTimers();
 			const deps = createMockDeps();
 			deps.internals.cache.set('key1', createEntry('data'));
-			deps.internals.gcTimers.set(
-				'key1',
-				setTimeout(() => {}, 1000)
-			);
+			const oldTimer = setTimeout(() => {}, 1000);
+			deps.internals.gcTimers.set('key1', oldTimer);
 			await Effect.runPromise(invalidateKey(deps, 'key1'));
-			expect(deps.internals.gcTimers.has('key1')).toBe(false);
+			// GC timer is reset by setEntry, not cleared
+			expect(deps.internals.gcTimers.has('key1')).toBe(true);
+			expect(deps.internals.gcTimers.get('key1')).not.toBe(oldTimer);
 			vi.useRealTimers();
 		});
 	});
 
 	describe('invalidatePattern', () => {
-		it('should remove entries matching pattern prefix', async () => {
+		it('should mark entries matching pattern prefix as invalidated', async () => {
 			const deps = createMockDeps();
 			deps.internals.cache.set('["users",1]', createEntry({ id: 1 }));
 			deps.internals.cache.set('["users",2]', createEntry({ id: 2 }));
 			deps.internals.cache.set('["posts",1]', createEntry({ id: 1 }));
 			await Effect.runPromise(invalidatePattern(deps, { pattern: ['users'] }));
-			expect(deps.internals.cache.has('["users",1]')).toBe(false);
-			expect(deps.internals.cache.has('["users",2]')).toBe(false);
-			expect(deps.internals.cache.has('["posts",1]')).toBe(true);
+			expect(deps.internals.cache.get('["users",1]')?.isInvalidated).toBe(true);
+			expect(deps.internals.cache.get('["users",2]')?.isInvalidated).toBe(true);
+			expect(deps.internals.cache.get('["posts",1]')?.isInvalidated).toBeFalsy();
 		});
 
 		it('should match nested patterns', async () => {
@@ -93,17 +95,25 @@ describe('invalidation handlers', () => {
 			await Effect.runPromise(
 				invalidatePattern(deps, { pattern: ['users', 'profile'] })
 			);
-			expect(deps.internals.cache.has('["users","profile",1]')).toBe(false);
-			expect(deps.internals.cache.has('["users","profile",2]')).toBe(false);
-			expect(deps.internals.cache.has('["users","settings",1]')).toBe(true);
+			expect(
+				deps.internals.cache.get('["users","profile",1]')?.isInvalidated
+			).toBe(true);
+			expect(
+				deps.internals.cache.get('["users","profile",2]')?.isInvalidated
+			).toBe(true);
+			expect(
+				deps.internals.cache.get('["users","settings",1]')?.isInvalidated
+			).toBeFalsy();
 		});
 
-		it('should handle empty pattern (matches none)', async () => {
+		it('should handle empty pattern (matches all)', async () => {
 			const deps = createMockDeps();
 			deps.internals.cache.set('["a"]', createEntry(1));
 			deps.internals.cache.set('["b"]', createEntry(2));
 			await Effect.runPromise(invalidatePattern(deps, { pattern: [] }));
 			expect(deps.internals.cache.size).toBe(2);
+			expect(deps.internals.cache.get('["a"]')?.isInvalidated).toBe(true);
+			expect(deps.internals.cache.get('["b"]')?.isInvalidated).toBe(true);
 		});
 
 		it('should notify subscribers for each invalidated key', async () => {
@@ -130,28 +140,31 @@ describe('invalidation handlers', () => {
 	});
 
 	describe('invalidateAll', () => {
-		it('should remove all entries', async () => {
+		it('should mark all entries as invalidated', async () => {
 			const deps = createMockDeps();
 			deps.internals.cache.set('a', createEntry(1));
 			deps.internals.cache.set('b', createEntry(2));
 			deps.internals.cache.set('c', createEntry(3));
 			await Effect.runPromise(invalidateAll(deps));
-			expect(deps.internals.cache.size).toBe(0);
+			expect(deps.internals.cache.size).toBe(3);
+			expect(deps.internals.cache.get('a')?.isInvalidated).toBe(true);
+			expect(deps.internals.cache.get('b')?.isInvalidated).toBe(true);
+			expect(deps.internals.cache.get('c')?.isInvalidated).toBe(true);
 		});
 
-		it('should clear all GC timers', async () => {
+		it('should reset GC timers rather than clear them', async () => {
 			vi.useFakeTimers();
 			const deps = createMockDeps();
-			deps.internals.gcTimers.set(
-				'a',
-				setTimeout(() => {}, 1000)
-			);
-			deps.internals.gcTimers.set(
-				'b',
-				setTimeout(() => {}, 1000)
-			);
+			deps.internals.cache.set('a', createEntry(1));
+			deps.internals.cache.set('b', createEntry(2));
+			const oldTimerA = setTimeout(() => {}, 1000);
+			const oldTimerB = setTimeout(() => {}, 1000);
+			deps.internals.gcTimers.set('a', oldTimerA);
+			deps.internals.gcTimers.set('b', oldTimerB);
 			await Effect.runPromise(invalidateAll(deps));
-			expect(deps.internals.gcTimers.size).toBe(0);
+			expect(deps.internals.gcTimers.size).toBe(2);
+			expect(deps.internals.gcTimers.get('a')).not.toBe(oldTimerA);
+			expect(deps.internals.gcTimers.get('b')).not.toBe(oldTimerB);
 			vi.useRealTimers();
 		});
 

--- a/packages/query/src/handlers/invalidation.ts
+++ b/packages/query/src/handlers/invalidation.ts
@@ -28,62 +28,80 @@ import type {
 	QueryKey,
 	InvalidatePatternInput,
 } from './types.js';
-import { notifySubscribersForKey } from './cache.js';
+import { getEntry, setEntry, notifySubscribersForKey } from './cache.js';
+import { partialMatchKey } from '../utils/index.js';
 
-const matchesKeyPattern = (pattern: QueryKey, key: QueryKey): boolean => {
-	if (pattern.length === 0) return false;
-	if (pattern.length > key.length) return false;
-	for (let i = 0; i < pattern.length; i++) {
-		if (JSON.stringify(pattern[i]) !== JSON.stringify(key[i])) {
-			return false;
-		}
-	}
-	return true;
-};
+const parseKey = (keyStr: string): QueryKey => JSON.parse(keyStr) as QueryKey;
 
+/**
+ * Mark a single cache entry as invalidated (stale).
+ * The entry is NOT deleted — it remains visible to observers
+ * while a background refetch is triggered via subscriber notification.
+ */
 export const invalidateKey = (
 	deps: QueryHandlerDeps,
 	keyStr: string
 ): Effect.Effect<void> =>
 	Effect.sync(() => {
-		const timer = deps.internals.gcTimers.get(keyStr);
-		if (timer) {
-			clearTimeout(timer);
-			deps.internals.gcTimers.delete(keyStr);
-		}
-		deps.internals.cache.delete(keyStr);
+		const entry = getEntry<unknown>(deps, { keyStr });
+		if (!entry) return;
+
+		setEntry(deps, {
+			keyStr,
+			entry: {
+				...entry,
+				isInvalidated: true,
+			},
+		});
+
 		notifySubscribersForKey(deps, keyStr);
 	});
 
+/**
+ * Mark all entries matching the prefix pattern as invalidated.
+ * Uses deep prefix matching so `['todos']` invalidates `['todos', {page:1}]`.
+ */
 export const invalidatePattern = (
 	deps: QueryHandlerDeps,
 	input: InvalidatePatternInput
 ): Effect.Effect<void> =>
 	Effect.sync(() => {
 		for (const keyStr of deps.internals.cache.keys()) {
-			const key = JSON.parse(keyStr) as QueryKey;
-			if (matchesKeyPattern(input.pattern, key)) {
-				const timer = deps.internals.gcTimers.get(keyStr);
-				if (timer) {
-					clearTimeout(timer);
-					deps.internals.gcTimers.delete(keyStr);
-				}
-				deps.internals.cache.delete(keyStr);
+			const key = parseKey(keyStr);
+			if (partialMatchKey(key, input.pattern)) {
+				const entry = getEntry<unknown>(deps, { keyStr });
+				if (!entry) continue;
+
+				setEntry(deps, {
+					keyStr,
+					entry: {
+						...entry,
+						isInvalidated: true,
+					},
+				});
+
 				notifySubscribersForKey(deps, keyStr);
 			}
 		}
 	});
 
+/**
+ * Mark every cache entry as invalidated.
+ */
 export const invalidateAll = (deps: QueryHandlerDeps): Effect.Effect<void> =>
 	Effect.sync(() => {
-		for (const timer of deps.internals.gcTimers.values()) {
-			clearTimeout(timer);
-		}
-		deps.internals.gcTimers.clear();
+		for (const keyStr of deps.internals.cache.keys()) {
+			const entry = getEntry<unknown>(deps, { keyStr });
+			if (!entry) continue;
 
-		const allKeys = Array.from(deps.internals.cache.keys());
-		deps.internals.cache.clear();
-		for (const keyStr of allKeys) {
+			setEntry(deps, {
+				keyStr,
+				entry: {
+					...entry,
+					isInvalidated: true,
+				},
+			});
+
 			notifySubscribersForKey(deps, keyStr);
 		}
 	});

--- a/packages/query/src/hooks/useInfiniteQuery.ts
+++ b/packages/query/src/hooks/useInfiniteQuery.ts
@@ -24,7 +24,7 @@
 
 import { Effect, Fiber, Duration, Predicate } from 'effect';
 import { signal, type Signal } from '@effuse/core';
-import { useQueryClient, type QueryKey } from '../client/index.js';
+import { useQueryClient, type QueryKey, type CacheEntry } from '../client/index.js';
 import { buildRetrySchedule, type RetryConfig } from '../execution/index.js';
 import { DEFAULT_STALE_TIME_MS, DEFAULT_TIMEOUT_MS } from '../config/index.js';
 import { InfiniteQueryError, TimeoutError } from '../errors/index.js';
@@ -81,6 +81,7 @@ export interface UseInfiniteQueryResult<TData> {
 	readonly refetch: () => Promise<void>;
 
 	readonly allPagesData: Signal<TData[] | undefined>;
+	readonly dispose: () => void;
 }
 
 // Infinite query page collection
@@ -137,6 +138,19 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 	let activeFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
 
 	let isInternalUpdate = false;
+
+	const cacheKey = [...queryKey, 'infinite'];
+
+	const writeCache = (data: InfiniteData<TData>): void => {
+		const existing = client.get<InfiniteData<TData>>(cacheKey);
+		const entry: CacheEntry<InfiniteData<TData>> = {
+			data,
+			dataUpdatedAt: Date.now(),
+			status: 'success',
+			fetchCount: (existing?.fetchCount ?? 0) + 1,
+		};
+		client.set(cacheKey, entry);
+	};
 
 	const updateDerivedState = (): void => {
 		const status = statusSignal.value;
@@ -221,6 +235,7 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 			hasNextPageSignal.value = nextNext !== undefined;
 
 			statusSignal.value = 'success';
+			writeCache(newData);
 			updateDerivedState();
 			isInternalUpdate = false;
 		} catch (error) {
@@ -273,6 +288,7 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 			hasPreviousPageSignal.value = prevPrev !== undefined;
 
 			statusSignal.value = 'success';
+			writeCache(newData);
 			updateDerivedState();
 			isInternalUpdate = false;
 		} catch (error) {
@@ -320,6 +336,7 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 
 			statusSignal.value = 'success';
 			errorSignal.value = undefined;
+			writeCache(newData);
 			updateDerivedState();
 			isInternalUpdate = false;
 		} catch (error) {
@@ -334,7 +351,6 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 		}
 	};
 
-	const cacheKey = [...queryKey, 'infinite'];
 	const cached = client.get<InfiniteData<TData>>(cacheKey);
 	if (cached) {
 		dataSignal.value = cached.data;
@@ -349,7 +365,7 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 		updateDerivedState();
 	}
 
-	client.subscribe(cacheKey, () => {
+	const unsubscribe = client.subscribe(cacheKey, () => {
 		if (enabled && !isInternalUpdate) {
 			refetch();
 		}
@@ -358,6 +374,14 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 	if (enabled && (!cached || client.isStale(cacheKey, staleTime))) {
 		refetch();
 	}
+
+	const dispose = (): void => {
+		unsubscribe();
+		if (activeFiber) {
+			Effect.runFork(Fiber.interrupt(activeFiber));
+			activeFiber = null;
+		}
+	};
 
 	return {
 		data: dataSignal,
@@ -375,5 +399,6 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 		fetchPreviousPage,
 		refetch,
 		allPagesData: allPagesDataSignal,
+		dispose,
 	};
 };

--- a/packages/query/src/hooks/useQueries.ts
+++ b/packages/query/src/hooks/useQueries.ts
@@ -22,11 +22,10 @@
  * SOFTWARE.
  */
 
-import { Effect, Duration } from 'effect';
+import { Effect } from 'effect';
 import { signal, type Signal } from '@effuse/core';
-import { useQueryClient, type QueryKey } from '../client/index.js';
-import { DEFAULT_TIMEOUT_MS } from '../config/index.js';
-import { QueryFetchError, TimeoutError } from '../errors/index.js';
+import { useQuery } from './useQuery.js';
+import type { QueryKey } from '../client/index.js';
 
 // Parallel query configuration
 export interface UseQueriesOptions<T> {
@@ -54,87 +53,22 @@ export interface UseQueriesResult<T> {
 export const useQueries = <T>(
 	queries: ReadonlyArray<UseQueriesOptions<T>>
 ): UseQueriesResult<T>[] => {
-	const client = queries[0]?.client ?? useQueryClient();
-	// TODO(#144): useQueries currently bypasses the cache entirely.
-	// It should build QueryObservers and read from / write to the cache.
-	void client;
+	return queries.map((q) => {
+		const result = useQuery<T>({
+			queryKey: q.queryKey,
+			queryFn: q.queryFn,
+			...(q.enabled !== undefined ? { enabled: q.enabled } : {}),
+			...(q.client !== undefined ? { client: q.client } : {}),
+		});
 
-	const enabledQueries = queries.filter((q) => q.enabled !== false);
-
-	const results: UseQueriesResult<T>[] = queries.map(() => ({
-		data: signal<T | undefined>(undefined),
-		error: signal<Error | undefined>(undefined),
-		isPending: signal<boolean>(true),
-		isSuccess: signal<boolean>(false),
-		isError: signal<boolean>(false),
-	}));
-
-	if (enabledQueries.length === 0) {
-		return results;
-	}
-
-	const queryIndexMap = new Map<string, number>();
-	queries.forEach((q, index) => {
-		queryIndexMap.set(JSON.stringify(q.queryKey), index);
+		return {
+			data: result.data,
+			error: result.error,
+			isPending: result.isPending,
+			isSuccess: result.isSuccess,
+			isError: result.isError,
+		};
 	});
-
-	const parallelEffect = Effect.all(
-		enabledQueries.map((q) =>
-			Effect.tryPromise({
-				try: () => q.queryFn(),
-				catch: (error) =>
-					new QueryFetchError({
-						message: error instanceof Error ? error.message : String(error),
-						cause: error,
-					}),
-			}).pipe(
-				Effect.timeoutFail({
-					duration: Duration.millis(DEFAULT_TIMEOUT_MS),
-					onTimeout: () => new TimeoutError({ durationMs: DEFAULT_TIMEOUT_MS }),
-				}),
-				Effect.map((data) => ({
-					queryKey: q.queryKey,
-					data,
-					error: undefined as Error | undefined,
-				})),
-				Effect.catchAll((error: Error) =>
-					Effect.succeed({
-						queryKey: q.queryKey,
-						data: undefined as T | undefined,
-						error,
-					})
-				)
-			)
-		),
-		{ concurrency: 'unbounded' }
-	);
-
-	Effect.runFork(
-		parallelEffect.pipe(
-			Effect.tap((queryResults) =>
-				Effect.sync(() => {
-					for (const result of queryResults) {
-						const index = queryIndexMap.get(JSON.stringify(result.queryKey));
-						if (index !== undefined) {
-							const r = results[index];
-							if (r) {
-								if (result.error) {
-									r.error.value = result.error;
-									r.isError.value = true;
-								} else {
-									r.data.value = result.data;
-									r.isSuccess.value = true;
-								}
-								r.isPending.value = false;
-							}
-						}
-					}
-				})
-			)
-		)
-	);
-
-	return results;
 };
 
 // Combined query result state

--- a/packages/query/src/utils/index.ts
+++ b/packages/query/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { deepEqual } from './deep-equal.js';
+export { partialMatchKey } from './partial-match-key.js';

--- a/packages/query/src/utils/partial-match-key.test.ts
+++ b/packages/query/src/utils/partial-match-key.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { partialMatchKey } from './partial-match-key.js';
+
+describe('partialMatchKey', () => {
+	it('should match exact arrays', () => {
+		expect(partialMatchKey(['todos'], ['todos'])).toBe(true);
+	});
+
+	it('should match prefix arrays', () => {
+		expect(partialMatchKey(['todos', { page: 1 }], ['todos'])).toBe(true);
+		expect(partialMatchKey(['todos', { page: 1 }], ['todos', { page: 1 }])).toBe(true);
+	});
+
+	it('should not match if pattern is longer than key', () => {
+		expect(partialMatchKey(['todos'], ['todos', { page: 1 }])).toBe(false);
+	});
+
+	it('should match nested object prefixes', () => {
+		expect(
+			partialMatchKey(['users', { id: 1, name: 'a' }], ['users', { id: 1 }])
+		).toBe(true);
+		expect(
+			partialMatchKey(['users', { id: 1, name: 'a' }], ['users', { id: 2 }])
+		).toBe(false);
+	});
+
+	it('should handle primitives', () => {
+		expect(partialMatchKey(['todos', 1], ['todos', 1])).toBe(true);
+		expect(partialMatchKey(['todos', 1], ['todos', 2])).toBe(false);
+	});
+
+	it('should handle null safely', () => {
+		expect(partialMatchKey(['todos', null], ['todos', null])).toBe(true);
+		expect(partialMatchKey(['todos'], ['todos', null])).toBe(false);
+	});
+
+	it('should handle empty arrays', () => {
+		expect(partialMatchKey([], [])).toBe(true);
+		expect(partialMatchKey(['a'], [])).toBe(true);
+	});
+});

--- a/packages/query/src/utils/partial-match-key.ts
+++ b/packages/query/src/utils/partial-match-key.ts
@@ -1,0 +1,59 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import type { QueryKey } from '../client/types.js';
+
+/**
+ * Checks if key `b` partially matches key `a`.
+ *
+ * For arrays, every element of `b` must deeply equal the corresponding
+ * element of `a`. This allows prefix matching so that `['todos']` matches
+ * `['todos', { page: 1 }]`.
+ *
+ * For objects, every own property of `b` must deeply equal the corresponding
+ * property of `a`.
+ */
+export function partialMatchKey(a: QueryKey, b: QueryKey): boolean;
+export function partialMatchKey(a: any, b: any): boolean {
+	if (a === b) {
+		return true;
+	}
+
+	if (typeof a !== typeof b) {
+		return false;
+	}
+
+	if (a === null || b === null) {
+		return false;
+	}
+
+	if (typeof a === 'object' && typeof b === 'object') {
+		const bKeys = Object.keys(b);
+		return bKeys.every((key) =>
+			partialMatchKey((a as any)[key], (b as any)[key])
+		);
+	}
+
+	return false;
+}


### PR DESCRIPTION
## Summary
Rewrites Effuse Query's invalidation system to match production TanStack Query semantics, closing #144.

## Key Changes
- **Invalidation no longer deletes cache entries** — it marks them `isInvalidated: true`, so active observers can show stale data while refetching in the background. Eliminates loading-state flashes on mutation success.
- **`partialMatchKey`** — replaces `JSON.stringify` per-element comparison with deep prefix matching. `['todos']` now correctly invalidates `['todos', {page: 1}]`.
- **Imperative cache API** — new methods on `QueryClientApi`:
  - `setQueryData(key, updater)` — direct cache writes; updater can be a function
  - `getQueryData(key)` — read cached data only
  - `getQueryState(key)` — read full cache entry
  - `removeQueries(pattern)` — actual eviction with prefix matching
- **`useInfiniteQuery` cache write-back** — every successful `fetchNextPage` / `fetchPreviousPage` / `refetch` now persists `InfiniteData` to the cache.
- **`useQueries` delegates to `useQuery`** — fixes cache bypass; each parallel query now participates in the cache lifecycle.
- **`useInfiniteQuery.dispose()`** — added missing cleanup for subscriber + active fiber.

## Verification
- TypeScript typecheck passes
- 77 tests passing (12 new tests for invalidation, partialMatchKey, and cache API)
- No breaking changes to hook signatures

## Usage Example
```ts
const queryClient = useQueryClient();

// After mutation success — update cache directly instead of invalidating
queryClient.setQueryData(['todo', 5], (old) => old ? { ...old, done: true } : old);

// Or invalidate related queries to trigger background refetch
await queryClient.invalidateQueries(['todos']);
```