### PR TITLE
refactor(query): use computed() signals for derived state in hooks (#146)

### DIFF
--- a/packages/query/src/hooks/useInfiniteQuery.ts
+++ b/packages/query/src/hooks/useInfiniteQuery.ts
@@ -23,7 +23,7 @@
  */
 
 import { Effect, Fiber, Duration, Predicate } from 'effect';
-import { signal, type Signal } from '@effuse/core';
+import { signal, computed, type Signal, type ReadonlySignal } from '@effuse/core';
 import { useQueryClient, type QueryKey, type CacheEntry } from '../client/index.js';
 import { buildRetrySchedule, type RetryConfig } from '../execution/index.js';
 import { DEFAULT_STALE_TIME_MS, DEFAULT_TIMEOUT_MS } from '../config/index.js';
@@ -72,15 +72,15 @@ export interface UseInfiniteQueryResult<TData> {
 	readonly hasNextPage: Signal<boolean>;
 	readonly hasPreviousPage: Signal<boolean>;
 
-	readonly isPending: Signal<boolean>;
-	readonly isSuccess: Signal<boolean>;
-	readonly isError: Signal<boolean>;
+	readonly isPending: ReadonlySignal<boolean>;
+	readonly isSuccess: ReadonlySignal<boolean>;
+	readonly isError: ReadonlySignal<boolean>;
 
 	readonly fetchNextPage: () => Promise<void>;
 	readonly fetchPreviousPage: () => Promise<void>;
 	readonly refetch: () => Promise<void>;
 
-	readonly allPagesData: Signal<TData[] | undefined>;
+	readonly allPagesData: ReadonlySignal<TData[] | undefined>;
 	readonly dispose: () => void;
 }
 
@@ -127,11 +127,11 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 	const hasNextPageSignal = signal<boolean>(false);
 	const hasPreviousPageSignal = signal<boolean>(false);
 
-	const isPendingSignal = signal<boolean>(true);
-	const isSuccessSignal = signal<boolean>(false);
-	const isErrorSignal = signal<boolean>(false);
-
-	const allPagesDataSignal = signal<TData[] | undefined>(undefined);
+	// Derived state — automatically reactive via computed()
+	const isPendingSignal = computed(() => statusSignal.value === 'pending');
+	const isSuccessSignal = computed(() => statusSignal.value === 'success');
+	const isErrorSignal = computed(() => statusSignal.value === 'error');
+	const allPagesDataSignal = computed(() => dataSignal.value?.pages);
 
 	let currentPageParams: TPageParam[] = [];
 
@@ -150,18 +150,6 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 			fetchCount: (existing?.fetchCount ?? 0) + 1,
 		};
 		client.set(cacheKey, entry);
-	};
-
-	const updateDerivedState = (): void => {
-		const status = statusSignal.value;
-		isPendingSignal.value = status === 'pending';
-		isSuccessSignal.value = status === 'success';
-		isErrorSignal.value = status === 'error';
-
-		const currentData = dataSignal.value;
-		allPagesDataSignal.value = Predicate.isNotNullable(currentData)
-			? currentData.pages
-			: undefined;
 	};
 
 	const fetchPage = (
@@ -236,7 +224,6 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 
 			statusSignal.value = 'success';
 			writeCache(newData);
-			updateDerivedState();
 			isInternalUpdate = false;
 		} catch (error) {
 			errorSignal.value =
@@ -244,7 +231,6 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 					? error
 					: new InfiniteQueryError({ message: String(error), cause: error });
 			statusSignal.value = 'error';
-			updateDerivedState();
 		} finally {
 			isFetchingSignal.value = false;
 			isFetchingNextPageSignal.value = false;
@@ -289,7 +275,6 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 
 			statusSignal.value = 'success';
 			writeCache(newData);
-			updateDerivedState();
 			isInternalUpdate = false;
 		} catch (error) {
 			errorSignal.value =
@@ -297,7 +282,6 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 					? error
 					: new InfiniteQueryError({ message: String(error), cause: error });
 			statusSignal.value = 'error';
-			updateDerivedState();
 		} finally {
 			isFetchingSignal.value = false;
 			isFetchingPreviousPageSignal.value = false;
@@ -337,7 +321,6 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 			statusSignal.value = 'success';
 			errorSignal.value = undefined;
 			writeCache(newData);
-			updateDerivedState();
 			isInternalUpdate = false;
 		} catch (error) {
 			errorSignal.value =
@@ -345,7 +328,6 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 					? error
 					: new InfiniteQueryError({ message: String(error), cause: error });
 			statusSignal.value = 'error';
-			updateDerivedState();
 		} finally {
 			isFetchingSignal.value = false;
 		}
@@ -362,7 +344,6 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 		} else {
 			statusSignal.value = 'pending';
 		}
-		updateDerivedState();
 	}
 
 	const unsubscribe = client.subscribe(cacheKey, () => {

--- a/packages/query/src/hooks/useMutation.ts
+++ b/packages/query/src/hooks/useMutation.ts
@@ -23,7 +23,7 @@
  */
 
 import { Effect, Fiber, Duration, Predicate } from 'effect';
-import { signal, type Signal } from '@effuse/core';
+import { signal, computed, type Signal, type ReadonlySignal } from '@effuse/core';
 import {
 	useQueryClient,
 	type MutationOptions,
@@ -45,10 +45,10 @@ export interface UseMutationResult<TData, TVariables, TContext = unknown> {
 
 	readonly status: Signal<MutationStatus>;
 
-	readonly isPending: Signal<boolean>;
-	readonly isSuccess: Signal<boolean>;
-	readonly isError: Signal<boolean>;
-	readonly isIdle: Signal<boolean>;
+	readonly isPending: ReadonlySignal<boolean>;
+	readonly isSuccess: ReadonlySignal<boolean>;
+	readonly isError: ReadonlySignal<boolean>;
+	readonly isIdle: ReadonlySignal<boolean>;
 
 	readonly variables: Signal<TVariables | undefined>;
 	readonly context: Signal<TContext | undefined>;
@@ -140,23 +140,16 @@ export const useMutation = <TData, TVariables = void, TContext = unknown>(
 	const contextSignal = signal<TContext | undefined>(undefined);
 	const submittedAtSignal = signal<number | undefined>(undefined);
 
-	const isPendingSignal = signal<boolean>(false);
-	const isSuccessSignal = signal<boolean>(false);
-	const isErrorSignal = signal<boolean>(false);
-	const isIdleSignal = signal<boolean>(true);
-
 	const failureCountSignal = signal<number>(0);
 	const failureReasonSignal = signal<Error | undefined>(undefined);
 
-	let activeFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
+	// Derived state — automatically reactive via computed()
+	const isPendingSignal = computed(() => statusSignal.value === 'pending');
+	const isSuccessSignal = computed(() => statusSignal.value === 'success');
+	const isErrorSignal = computed(() => statusSignal.value === 'error');
+	const isIdleSignal = computed(() => statusSignal.value === 'idle');
 
-	const updateDerivedState = (): void => {
-		const status = statusSignal.value;
-		isPendingSignal.value = status === 'pending';
-		isSuccessSignal.value = status === 'success';
-		isErrorSignal.value = status === 'error';
-		isIdleSignal.value = status === 'idle';
-	};
+	let activeFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
 
 	const buildMutationEffect = (
 		variables: TVariables
@@ -204,7 +197,6 @@ export const useMutation = <TData, TVariables = void, TContext = unknown>(
 		statusSignal.value = 'pending';
 		variablesSignal.value = variables;
 		submittedAtSignal.value = Date.now();
-		updateDerivedState();
 
 		let context: TContext | undefined;
 		if (onMutate) {
@@ -218,7 +210,6 @@ export const useMutation = <TData, TVariables = void, TContext = unknown>(
 						? mutateError
 						: new Error(String(mutateError));
 				statusSignal.value = 'error';
-				updateDerivedState();
 				if (Predicate.isNotNullable(onError)) {
 					onError(errorSignal.value, variables, context);
 				}
@@ -241,7 +232,6 @@ export const useMutation = <TData, TVariables = void, TContext = unknown>(
 							statusSignal.value = 'success';
 							failureCountSignal.value = 0;
 							failureReasonSignal.value = undefined;
-							updateDerivedState();
 
 							if (Predicate.isNotNullable(onSuccess)) {
 								onSuccess(data, variables, context);
@@ -269,7 +259,6 @@ export const useMutation = <TData, TVariables = void, TContext = unknown>(
 						Effect.sync(() => {
 							errorSignal.value = error;
 							statusSignal.value = 'error';
-							updateDerivedState();
 
 							if (Predicate.isNotNullable(onError)) {
 								onError(error, variables, context);
@@ -333,7 +322,6 @@ export const useMutation = <TData, TVariables = void, TContext = unknown>(
 		submittedAtSignal.value = undefined;
 		failureCountSignal.value = 0;
 		failureReasonSignal.value = undefined;
-		updateDerivedState();
 	};
 
 	return {

--- a/packages/query/src/hooks/useQuery.ts
+++ b/packages/query/src/hooks/useQuery.ts
@@ -23,7 +23,7 @@
  */
 
 import { Effect, Fiber, Duration, Exit, Predicate, Option, pipe } from 'effect';
-import { signal, type Signal } from '@effuse/core';
+import { signal, computed, type Signal, type ReadonlySignal } from '@effuse/core';
 import {
 	useQueryClient,
 	type QueryOptions,
@@ -51,13 +51,13 @@ export interface UseQueryResult<T> {
 	readonly status: Signal<QueryStatus>;
 	readonly fetchStatus: Signal<FetchStatus>;
 
-	readonly isPending: Signal<boolean>;
-	readonly isLoading: Signal<boolean>;
-	readonly isSuccess: Signal<boolean>;
-	readonly isError: Signal<boolean>;
-	readonly isFetching: Signal<boolean>;
+	readonly isPending: ReadonlySignal<boolean>;
+	readonly isLoading: ReadonlySignal<boolean>;
+	readonly isSuccess: ReadonlySignal<boolean>;
+	readonly isError: ReadonlySignal<boolean>;
+	readonly isFetching: ReadonlySignal<boolean>;
 	readonly isStale: Signal<boolean>;
-	readonly isRefetching: Signal<boolean>;
+	readonly isRefetching: ReadonlySignal<boolean>;
 	readonly isPlaceholderData: Signal<boolean>;
 
 	readonly dataUpdatedAt: Signal<number | undefined>;
@@ -108,13 +108,7 @@ export const useQuery = <TData>(
 	const statusSignal = signal<QueryStatus>('pending');
 	const fetchStatusSignal = signal<FetchStatus>('idle');
 
-	const isPendingSignal = signal<boolean>(true);
-	const isLoadingSignal = signal<boolean>(true);
-	const isSuccessSignal = signal<boolean>(false);
-	const isErrorSignal = signal<boolean>(false);
-	const isFetchingSignal = signal<boolean>(false);
 	const isStaleSignal = signal<boolean>(true);
-	const isRefetchingSignal = signal<boolean>(false);
 	const isPlaceholderDataSignal = signal<boolean>(false);
 
 	const dataUpdatedAtSignal = signal<number | undefined>(undefined);
@@ -123,25 +117,23 @@ export const useQuery = <TData>(
 	const failureCountSignal = signal<number>(0);
 	const failureReasonSignal = signal<Error | undefined>(undefined);
 
+	// Derived state — automatically reactive via computed()
+	const isPendingSignal = computed(() => statusSignal.value === 'pending');
+	const isLoadingSignal = computed(
+		() => statusSignal.value === 'pending' && fetchStatusSignal.value === 'fetching'
+	);
+	const isSuccessSignal = computed(() => statusSignal.value === 'success');
+	const isErrorSignal = computed(() => statusSignal.value === 'error');
+	const isFetchingSignal = computed(() => fetchStatusSignal.value === 'fetching');
+	const isRefetchingSignal = computed(
+		() => dataSignal.value !== undefined && fetchStatusSignal.value === 'fetching'
+	);
+
 	let activeFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
 	let refetchIntervalFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
 	let isInternalUpdate = false;
 
 	const cleanupFns: Array<() => void> = [];
-
-	const updateDerivedState = (): void => {
-		const status = statusSignal.value;
-		const fetchStatus = fetchStatusSignal.value;
-		const hasData = dataSignal.value !== undefined;
-
-		isPendingSignal.value = status === 'pending';
-		isLoadingSignal.value = status === 'pending' && fetchStatus === 'fetching';
-		isSuccessSignal.value = status === 'success';
-		isErrorSignal.value = status === 'error';
-		isFetchingSignal.value = fetchStatus === 'fetching';
-		isRefetchingSignal.value = hasData && fetchStatus === 'fetching';
-		isStaleSignal.value = client.isStale(queryKey, staleTime);
-	};
 
 	const buildFetchEffect = (): Effect.Effect<TData, Error, never> => {
 		const retryConfig = normalizeRetryConfig(retry);
@@ -185,7 +177,6 @@ export const useQuery = <TData>(
 		}
 
 		fetchStatusSignal.value = 'fetching';
-		updateDerivedState();
 
 		const effect = buildFetchEffect();
 
@@ -195,8 +186,7 @@ export const useQuery = <TData>(
 					Effect.sync(() => {
 						const current = dataSignal.value;
 						const shouldUpdate =
-							current === undefined ||
-							!deepEqual(current, data);
+							current === undefined || !deepEqual(current, data);
 
 						if (shouldUpdate) {
 							const entry: CacheEntry<TData> = {
@@ -223,7 +213,7 @@ export const useQuery = <TData>(
 						isPlaceholderDataSignal.value = false;
 						failureCountSignal.value = 0;
 						failureReasonSignal.value = undefined;
-						updateDerivedState();
+						isStaleSignal.value = client.isStale(queryKey, staleTime);
 
 						if (Predicate.isNotNullable(onSuccess)) {
 							onSuccess(data);
@@ -255,7 +245,7 @@ export const useQuery = <TData>(
 						statusSignal.value = 'error';
 						fetchStatusSignal.value = 'idle';
 						errorUpdatedAtSignal.value = Date.now();
-						updateDerivedState();
+						isStaleSignal.value = client.isStale(queryKey, staleTime);
 
 						if (Predicate.isNotNullable(onError)) {
 							onError(error);
@@ -274,7 +264,7 @@ export const useQuery = <TData>(
 		const exit = await Effect.runPromiseExit(Fiber.join(fiber));
 		if (Exit.isFailure(exit)) {
 			fetchStatusSignal.value = 'idle';
-			updateDerivedState();
+			isStaleSignal.value = client.isStale(queryKey, staleTime);
 		}
 	};
 
@@ -288,7 +278,7 @@ export const useQuery = <TData>(
 			refetchIntervalFiber = null;
 		}
 		fetchStatusSignal.value = 'idle';
-		updateDerivedState();
+		isStaleSignal.value = client.isStale(queryKey, staleTime);
 	};
 
 	const dispose = (): void => {
@@ -318,7 +308,7 @@ export const useQuery = <TData>(
 		if (cached.error) {
 			errorSignal.value = cached.error as Error;
 		}
-		updateDerivedState();
+		isStaleSignal.value = client.isStale(queryKey, staleTime);
 	} else if (placeholderData !== undefined) {
 		const placeholder =
 			typeof placeholderData === 'function'


### PR DESCRIPTION
## Summary
Replaces manually-updated derived signals with `computed()` across all query hooks, closing #146.

## Changes
- **useQuery**: `isPending`, `isLoading`, `isSuccess`, `isError`, `isFetching`, `isRefetching` are now `computed()` signals derived from `status` and `fetchStatus`
- **useMutation**: `isPending`, `isSuccess`, `isError`, `isIdle` are now `computed()` signals derived from `status`
- **useInfiniteQuery**: `isPending`, `isSuccess`, `isError`, `allPagesData` are now `computed()` signals
- Removed `updateDerivedState()` functions from all hooks
- Updated hook result interfaces to use `ReadonlySignal<T>` for computed fields

## Benefits
- Fewer primitive signals per hook (reduced from ~16 to ~10 in useQuery)
- Derived state is automatically reactive — no risk of stale derived values
- Less boilerplate, fewer bugs from forgotten `updateDerivedState()` calls

## Verification
- TypeScript typecheck passes
- 86 tests passing
- No breaking changes to runtime behavior