### PR TITLE
feat(query): QueryObserver architecture — state machine, shared queries, memoized select, AbortSignal (#154)

### DIFF
--- a/packages/query/src/client/client.ts
+++ b/packages/query/src/client/client.ts
@@ -44,6 +44,8 @@ import {
 	type QueryCacheInternals,
 	type QueryHandlerDeps,
 } from '../handlers/index.js';
+import { QueryCache, Query } from '../core/index.js';
+import type { QueryConfig } from '../core/types.js';
 
 const serializeKey = (key: QueryKey): string => JSON.stringify(key);
 
@@ -97,6 +99,12 @@ export interface QueryClientApi {
 	readonly getQueryState: <T>(key: QueryKey) => CacheEntry<T> | undefined;
 	/** Remove queries matching the given filters. */
 	readonly removeQueries: (filters: QueryFilters | QueryKey) => void;
+	/** Get or create a Query from the new QueryCache. */
+	readonly getQuery: <TData, TError = Error>(
+		config: QueryConfig<TData, TError>
+	) => Query<TData, TError>;
+	/** The underlying QueryCache instance. */
+	readonly queryCache: QueryCache;
 }
 
 export class QueryClient extends Context.Tag('effuse/query/QueryClient')<
@@ -118,6 +126,8 @@ const createQueryClientImpl = (): QueryClientApi => {
 			staleTimeMs: DEFAULT_STALE_TIME_MS,
 		},
 	};
+
+	const queryCache = new QueryCache();
 
 	return {
 		get: <T>(key: QueryKey): CacheEntry<T> | undefined => {
@@ -300,6 +310,36 @@ const createQueryClientImpl = (): QueryClientApi => {
 		removeQueries: (filters: QueryFilters | QueryKey): void => {
 			removeWithFilters(deps, normalizeFilters(filters));
 		},
+
+		getQuery: <TData, TError = Error>(
+			config: QueryConfig<TData, TError>
+		): Query<TData, TError> => {
+			const query = queryCache.getOrCreate(config);
+
+			// Seed from old cache if present and query is fresh
+			const keyStr = serializeKey(config.queryKey);
+			const existing = getEntry<TData>(deps, { keyStr });
+			if (
+				existing &&
+				query.currentState.fetchCount === 0 &&
+				existing.data !== undefined
+			) {
+				query.setState({
+					data: existing.data,
+					status: existing.status === 'error' ? 'error' : 'success',
+					dataUpdatedAt: existing.dataUpdatedAt,
+					fetchCount: existing.fetchCount ?? 0,
+					isInvalidated: existing.isInvalidated ?? false,
+					...(existing.error
+						? { error: existing.error as TError, errorUpdatedAt: existing.errorUpdatedAt ?? Date.now() }
+						: {}),
+				});
+			}
+
+			return query;
+		},
+
+		queryCache,
 	};
 };
 

--- a/packages/query/src/core/index.ts
+++ b/packages/query/src/core/index.ts
@@ -1,0 +1,41 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+export { Query } from './query.js';
+export { QueryObserver } from './query-observer.js';
+export { QueryCache } from './query-cache.js';
+
+export type {
+	QueryKey,
+	QueryStatus,
+	FetchStatus,
+	QueryFunction,
+	QueryState,
+	QueryAction,
+	QueryConfig,
+	QueryObserverOptions,
+	QueryObserverResult,
+	QueryObserverListener,
+	QuerySnapshot,
+} from './types.js';

--- a/packages/query/src/core/query-cache.test.ts
+++ b/packages/query/src/core/query-cache.test.ts
@@ -1,0 +1,129 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { QueryCache } from './query-cache.js';
+import { Query } from './query.js';
+
+describe('QueryCache', () => {
+	it('should create and retrieve queries', () => {
+		const cache = new QueryCache();
+		const query = cache.getOrCreate({
+			queryKey: ['users', 1],
+			queryFn: async () => 'user',
+		});
+
+		expect(query).toBeInstanceOf(Query);
+		expect(query.queryKey).toEqual(['users', 1]);
+	});
+
+	it('should return existing query for same key', () => {
+		const cache = new QueryCache();
+		const q1 = cache.getOrCreate({
+			queryKey: ['shared'],
+			queryFn: async () => 'a',
+		});
+		const q2 = cache.getOrCreate({
+			queryKey: ['shared'],
+			queryFn: async () => 'b',
+		});
+
+		expect(q1).toBe(q2);
+	});
+
+	it('should create different queries for different keys', () => {
+		const cache = new QueryCache();
+		const q1 = cache.getOrCreate({
+			queryKey: ['a'],
+			queryFn: async () => 'a',
+		});
+		const q2 = cache.getOrCreate({
+			queryKey: ['b'],
+			queryFn: async () => 'b',
+		});
+
+		expect(q1).not.toBe(q2);
+	});
+
+	it('should get existing query without creating', () => {
+		const cache = new QueryCache();
+		const existing = cache.get(['missing']);
+		expect(existing).toBeUndefined();
+
+		cache.getOrCreate({
+			queryKey: ['exists'],
+			queryFn: async () => 'data',
+		});
+
+		const found = cache.get(['exists']);
+		expect(found).toBeDefined();
+	});
+
+	it('should remove queries', () => {
+		const cache = new QueryCache();
+		cache.getOrCreate({
+			queryKey: ['remove-me'],
+			queryFn: async () => 'data',
+		});
+
+		expect(cache.get(['remove-me'])).toBeDefined();
+		cache.remove(['remove-me']);
+		expect(cache.get(['remove-me'])).toBeUndefined();
+	});
+
+	it('should return all queries', () => {
+		const cache = new QueryCache();
+		cache.getOrCreate({ queryKey: ['a'], queryFn: async () => 'a' });
+		cache.getOrCreate({ queryKey: ['b'], queryFn: async () => 'b' });
+
+		const all = cache.getAll();
+		expect(all).toHaveLength(2);
+	});
+
+	it('should return all snapshots', () => {
+		const cache = new QueryCache();
+		cache.getOrCreate({ queryKey: ['a'], queryFn: async () => 'a' });
+
+		const snapshots = cache.getAllSnapshots();
+		expect(snapshots).toHaveLength(1);
+		expect(snapshots[0].queryKey).toEqual(['a']);
+	});
+
+	it('should clear all queries', () => {
+		const cache = new QueryCache();
+		cache.getOrCreate({ queryKey: ['a'], queryFn: async () => 'a' });
+		cache.getOrCreate({ queryKey: ['b'], queryFn: async () => 'b' });
+
+		cache.clear();
+		expect(cache.size).toBe(0);
+		expect(cache.getAll()).toHaveLength(0);
+	});
+
+	it('should track size', () => {
+		const cache = new QueryCache();
+		expect(cache.size).toBe(0);
+		cache.getOrCreate({ queryKey: ['a'], queryFn: async () => 'a' });
+		expect(cache.size).toBe(1);
+	});
+});

--- a/packages/query/src/core/query-cache.ts
+++ b/packages/query/src/core/query-cache.ts
@@ -1,0 +1,122 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { Query } from './query.js';
+import type { QueryKey, QueryConfig, QuerySnapshot } from './types.js';
+
+const hashKey = (key: QueryKey): string => JSON.stringify(key);
+
+/**
+ * Manages Query instances by their query key.
+ * Creates queries on demand and schedules garbage collection.
+ */
+export class QueryCache {
+	private queries: Map<string, Query<unknown, Error>> = new Map();
+
+	/**
+	 * Get or create a query for the given key and config.
+	 */
+	getOrCreate<TData, TError = Error>(
+		config: QueryConfig<TData, TError>
+	): Query<TData, TError> {
+		const hash = hashKey(config.queryKey);
+		const existing = this.queries.get(hash);
+
+		if (existing) {
+			// Update config if options changed
+			(existing as Query<TData, TError>).options = config;
+			return existing as Query<TData, TError>;
+		}
+
+		const query = new Query<TData, TError>(config);
+		this.queries.set(hash, query as Query<unknown, Error>);
+		return query;
+	}
+
+	/**
+	 * Get an existing query without creating one.
+	 */
+	get<TData, TError = Error>(key: QueryKey): Query<TData, TError> | undefined {
+		const hash = hashKey(key);
+		const query = this.queries.get(hash);
+		return query as Query<TData, TError> | undefined;
+	}
+
+	/**
+	 * Remove a query from the cache.
+	 */
+	remove(key: QueryKey): boolean {
+		const hash = hashKey(key);
+		const query = this.queries.get(hash);
+		if (query) {
+			query.destroy();
+			this.queries.delete(hash);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Remove all inactive queries matching a predicate.
+	 */
+	removeInactive(predicate?: (query: Query<unknown, Error>) => boolean): void {
+		for (const [hash, query] of this.queries) {
+			if (!query.isActive && (!predicate || predicate(query))) {
+				query.destroy();
+				this.queries.delete(hash);
+			}
+		}
+	}
+
+	/**
+	 * Get all queries.
+	 */
+	getAll(): Query<unknown, Error>[] {
+		return Array.from(this.queries.values());
+	}
+
+	/**
+	 * Get snapshots of all queries.
+	 */
+	getAllSnapshots(): QuerySnapshot<unknown, Error>[] {
+		return this.getAll().map((q) => q.snapshot());
+	}
+
+	/**
+	 * Clear all queries.
+	 */
+	clear(): void {
+		for (const query of this.queries.values()) {
+			query.destroy();
+		}
+		this.queries.clear();
+	}
+
+	/**
+	 * Get the number of cached queries.
+	 */
+	get size(): number {
+		return this.queries.size;
+	}
+}

--- a/packages/query/src/core/query-observer.test.ts
+++ b/packages/query/src/core/query-observer.test.ts
@@ -1,0 +1,265 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { Query } from './query.js';
+import { QueryObserver } from './query-observer.js';
+
+describe('QueryObserver', () => {
+	const createQuery = (overrides?: Partial<ConstructorParameters<typeof Query>[0]>) =>
+		new Query({
+			queryKey: ['observer-test'],
+			queryFn: async () => 'data',
+			...overrides,
+		});
+
+	it('should compute initial result from query state', () => {
+		const query = createQuery();
+		const observer = new QueryObserver(query, {
+			queryKey: ['observer-test'],
+			queryFn: async () => 'data',
+		});
+
+		const result = observer.getCurrentResult();
+		expect(result.status).toBe('pending');
+		expect(result.isPending).toBe(true);
+		expect(result.isFetching).toBe(false);
+	});
+
+	it('should update result when query succeeds', async () => {
+		const query = createQuery();
+		const observer = new QueryObserver(query, {
+			queryKey: ['observer-test'],
+			queryFn: async () => 'data',
+		});
+
+		const listener = vi.fn();
+		observer.subscribe(listener);
+
+		await query.fetch();
+
+		expect(listener).toHaveBeenCalled();
+		const result = observer.getCurrentResult();
+		expect(result.data).toBe('data');
+		expect(result.status).toBe('success');
+		expect(result.isSuccess).toBe(true);
+	});
+
+	it('should memoize select function', async () => {
+		const query = createQuery({ queryFn: async () => ({ count: 1 }) });
+		const select = vi.fn((data: { count: number }) => data.count);
+
+		const observer = new QueryObserver(query, {
+			queryKey: ['observer-test'],
+			queryFn: async () => ({ count: 1 }),
+			select,
+		});
+
+		await query.fetch();
+		expect(select).toHaveBeenCalledTimes(1);
+
+		// Fetch again with same data
+		await query.fetch();
+		expect(select).toHaveBeenCalledTimes(1);
+
+		// Fetch with different data
+		query.options = { ...query.options, queryFn: async () => ({ count: 2 }) };
+		await query.fetch();
+		expect(select).toHaveBeenCalledTimes(2);
+	});
+
+	it('should handle initialData', () => {
+		const query = createQuery();
+		const observer = new QueryObserver(query, {
+			queryKey: ['observer-test'],
+			queryFn: async () => 'fetched',
+			initialData: 'seed',
+		});
+
+		const result = observer.getCurrentResult();
+		expect(result.data).toBe('seed');
+		expect(result.status).toBe('success');
+		expect(result.isSuccess).toBe(true);
+		expect(result.isPending).toBe(false);
+	});
+
+	it('should prefer cached data over initialData', async () => {
+		const query = createQuery();
+		query.dispatch({ type: 'success', data: 'cached' });
+
+		const observer = new QueryObserver(query, {
+			queryKey: ['observer-test'],
+			queryFn: async () => 'fetched',
+			initialData: 'seed',
+		});
+
+		const result = observer.getCurrentResult();
+		expect(result.data).toBe('cached');
+	});
+
+	it('should handle placeholderData', () => {
+		const query = createQuery();
+		const observer = new QueryObserver(query, {
+			queryKey: ['observer-test'],
+			queryFn: async () => 'real',
+			placeholderData: 'placeholder',
+		});
+
+		const result = observer.getCurrentResult();
+		expect(result.data).toBe('placeholder');
+		expect(result.isPlaceholderData).toBe(true);
+	});
+
+	it('should handle placeholderData as function', () => {
+		const query = createQuery();
+		const observer = new QueryObserver(query, {
+			queryKey: ['observer-test'],
+			queryFn: async () => 'real',
+			placeholderData: (prev) => prev ?? 'fallback',
+		});
+
+		const result = observer.getCurrentResult();
+		expect(result.data).toBe('fallback');
+		expect(result.isPlaceholderData).toBe(true);
+	});
+
+	it('should support select with initialData', () => {
+		const query = createQuery();
+		const observer = new QueryObserver(query, {
+			queryKey: ['observer-test'],
+			queryFn: async () => ({ value: 10 }),
+			initialData: { value: 5 },
+			select: (data) => data.value,
+		});
+
+		const result = observer.getCurrentResult();
+		expect(result.data).toBe(5);
+		expect(result.status).toBe('success');
+	});
+
+	it('should only notify when tracked props change', async () => {
+		const query = createQuery();
+		const observer = new QueryObserver(query, {
+			queryKey: ['observer-test'],
+			queryFn: async () => 'data',
+			notifyOnChangeProps: ['data'],
+		});
+
+		const listener = vi.fn();
+		observer.subscribe(listener);
+
+		// First fetch - data changes
+		await query.fetch();
+		expect(listener).toHaveBeenCalledTimes(1);
+
+		// Second fetch with same data - no notification
+		await query.fetch();
+		expect(listener).toHaveBeenCalledTimes(1);
+	});
+
+	it('should handle select errors gracefully', () => {
+		const query = createQuery();
+		query.dispatch({ type: 'success', data: 'data' });
+
+		const observer = new QueryObserver(query, {
+			queryKey: ['observer-test'],
+			queryFn: async () => 'data',
+			select: () => {
+				throw new Error('select failed');
+			},
+		});
+
+		const result = observer.getCurrentResult();
+		expect(result.status).toBe('error');
+		expect(result.error?.message).toBe('select failed');
+	});
+
+	it('should support refetch through observer', async () => {
+		const query = createQuery();
+		const observer = new QueryObserver(query, {
+			queryKey: ['observer-test'],
+			queryFn: async () => 'data',
+		});
+
+		await observer.refetch();
+		expect(observer.getCurrentResult().data).toBe('data');
+	});
+
+	it('should clean up on destroy', () => {
+		const query = createQuery();
+		const observer = new QueryObserver(query, {
+			queryKey: ['observer-test'],
+			queryFn: async () => 'data',
+		});
+
+		expect(query.observerCount).toBe(1);
+		observer.destroy();
+		expect(query.observerCount).toBe(0);
+	});
+
+	it('should update result when options change', async () => {
+		const query = createQuery({ queryFn: async () => ({ value: 1 }) });
+		const observer = new QueryObserver(query, {
+			queryKey: ['observer-test'],
+			queryFn: async () => ({ value: 1 }),
+		});
+
+		await query.fetch();
+		expect(observer.getCurrentResult().data).toEqual({ value: 1 });
+
+		observer.setOptions({
+			select: (data: { value: number }) => data.value * 10,
+		});
+
+		expect(observer.getCurrentResult().data).toBe(10);
+	});
+
+	it('should handle error state', async () => {
+		const query = new Query({
+			queryKey: ['error'],
+			queryFn: async () => {
+				throw new Error('boom');
+			},
+			retry: false,
+		});
+
+		const observer = new QueryObserver(query, {
+			queryKey: ['error'],
+			queryFn: async () => {
+				throw new Error('boom');
+			},
+		});
+
+		try {
+			await query.fetch();
+		} catch {
+			// expected
+		}
+
+		const result = observer.getCurrentResult();
+		expect(result.status).toBe('error');
+		expect(result.isError).toBe(true);
+		expect(result.error?.message).toBe('boom');
+	});
+});

--- a/packages/query/src/core/query-observer.ts
+++ b/packages/query/src/core/query-observer.ts
@@ -1,0 +1,288 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import type {
+	QueryState,
+	QueryObserverOptions,
+	QueryObserverResult,
+	QueryObserverListener,
+} from './types.js';
+import { Query } from './query.js';
+import { deepEqual } from '../utils/index.js';
+
+const getPlaceholderData = <T>(
+	placeholderData: T | ((previousData: T | undefined) => T) | undefined,
+	previousData: T | undefined
+): T | undefined => {
+	if (placeholderData === undefined) return undefined;
+	if (typeof placeholderData === 'function') {
+		return (placeholderData as (previousData: T | undefined) => T)(previousData);
+	}
+	return placeholderData;
+};
+
+const createResult = <TData, TError, TSelected>(
+	query: Query<TData, TError>,
+	options: QueryObserverOptions<TData, TError, TSelected>,
+	previousResult?: QueryObserverResult<TSelected, TError>
+): QueryObserverResult<TSelected, TError> => {
+	const { currentState } = query;
+	const { select, initialData } = options;
+
+	let data: TSelected | undefined;
+	let isPlaceholderData = false;
+
+	if (currentState.data !== undefined) {
+		if (select) {
+			// Memoized select: only re-run if source data changed
+			if (
+				previousResult &&
+				query.currentState.data === (query as unknown as { _lastData: unknown })._lastData
+			) {
+				data = previousResult.data;
+			} else {
+				data = select(currentState.data);
+			}
+		} else {
+			data = currentState.data as unknown as TSelected;
+		}
+	} else if (initialData !== undefined) {
+		const initial =
+			typeof initialData === 'function'
+				? (initialData as () => TData)()
+				: initialData;
+		data = select ? select(initial) : (initial as unknown as TSelected);
+	} else {
+		const placeholder = getPlaceholderData(
+			options.placeholderData,
+			previousResult?.data
+		);
+		if (placeholder !== undefined) {
+			data = placeholder;
+			isPlaceholderData = true;
+		}
+	}
+
+	// When initialData is used and query hasn't fetched yet, override status to success
+	const hasInitialData =
+		initialData !== undefined && currentState.fetchCount === 0 && currentState.data === undefined;
+	const status = hasInitialData ? 'success' : currentState.status;
+
+	const isPending = status === 'pending';
+	const isLoading = isPending && currentState.fetchStatus === 'fetching';
+	const isSuccess = status === 'success';
+	const isError = status === 'error';
+	const isFetching = currentState.fetchStatus === 'fetching';
+	const isRefetching = isFetching && data !== undefined;
+
+	// Store last data reference for select memoization
+	(query as unknown as { _lastData: unknown })._lastData = currentState.data;
+
+	return {
+		data,
+		dataUpdatedAt: hasInitialData ? Date.now() : currentState.dataUpdatedAt,
+		error: currentState.error,
+		errorUpdatedAt: currentState.errorUpdatedAt,
+		status,
+		fetchStatus: currentState.fetchStatus,
+		isPending,
+		isLoading,
+		isSuccess,
+		isError,
+		isFetching,
+		isRefetching,
+		isStale: query.isStale,
+		isPlaceholderData,
+		fetchCount: currentState.fetchCount,
+	};
+};
+
+const shouldNotify = <TData, TError>(
+	prev: QueryObserverResult<TData, TError>,
+	next: QueryObserverResult<TData, TError>,
+	notifyOnChangeProps?: Array<keyof QueryObserverResult<TData, TError>>
+): boolean => {
+	if (!notifyOnChangeProps) {
+		// Default: notify on any change
+		return !deepEqual(prev, next);
+	}
+
+	for (const prop of notifyOnChangeProps) {
+		if (!deepEqual(prev[prop], next[prop])) {
+			return true;
+		}
+	}
+	return false;
+};
+
+/**
+ * Bridges a Query and a UI subscriber.
+ * Computes its own result from the query state and observer options,
+ * with memoized select and granular change tracking.
+ */
+export class QueryObserver<TData = unknown, TError = Error, TSelected = TData> {
+	private options: QueryObserverOptions<TData, TError, TSelected>;
+
+	private query: Query<TData, TError>;
+	private currentResult: QueryObserverResult<TSelected, TError>;
+	private listener: QueryObserverListener<TSelected, TError> | null = null;
+	private unsubscribeQuery: (() => void) | null = null;
+	private previousSelectError: Error | null = null;
+
+	constructor(
+		query: Query<TData, TError>,
+		options: QueryObserverOptions<TData, TError, TSelected>
+	) {
+		this.query = query;
+		this.options = options;
+		try {
+			this.currentResult = createResult(query, options);
+		} catch (error) {
+			const err = error instanceof Error ? error : new Error(String(error));
+			this.currentResult = {
+				data: undefined,
+				error: err as TError,
+				status: 'error',
+				fetchStatus: 'idle',
+				dataUpdatedAt: 0,
+				errorUpdatedAt: Date.now(),
+				isPending: false,
+				isLoading: false,
+				isSuccess: false,
+				isError: true,
+				isFetching: false,
+				isRefetching: false,
+				isStale: query.isStale,
+				isPlaceholderData: false,
+				fetchCount: 0,
+			};
+		}
+		this.subscribeToQuery();
+	}
+
+	getCurrentResult(): QueryObserverResult<TSelected, TError> {
+		return this.currentResult;
+	}
+
+	/**
+	 * Subscribe a listener to result changes.
+	 * Returns an unsubscribe function.
+	 */
+	subscribe(
+		listener: QueryObserverListener<TSelected, TError>
+	): () => void {
+		this.listener = listener;
+		return () => {
+			this.listener = null;
+		};
+	}
+
+	/**
+	 * Trigger a refetch of the underlying query.
+	 */
+	async refetch(): Promise<TData> {
+		return this.query.fetch();
+	}
+
+	/**
+	 * Update the observer options and recompute the result.
+	 */
+	setOptions(
+		options: Partial<QueryObserverOptions<TData, TError, TSelected>>
+	): void {
+		const selectChanged = 'select' in options;
+		this.options = { ...this.options, ...options };
+		if (selectChanged) {
+			// Force select re-evaluation by clearing memoization
+			(this.query as unknown as { _lastData?: unknown })._lastData = undefined;
+		}
+		this.updateResult();
+	}
+
+	/**
+	 * Called by the Query when its state changes.
+	 */
+	onQueryUpdate(): void {
+		this.updateResult();
+	}
+
+	/**
+	 * Clean up the observer and unsubscribe from the query.
+	 */
+	destroy(): void {
+		if (this.unsubscribeQuery) {
+			this.unsubscribeQuery();
+			this.unsubscribeQuery = null;
+		}
+		this.listener = null;
+	}
+
+	private subscribeToQuery(): void {
+		this.unsubscribeQuery = this.query.addObserver(this);
+	}
+
+	private updateResult(): void {
+		const prevResult = this.currentResult;
+
+		try {
+			this.currentResult = createResult(this.query, this.options, prevResult);
+			this.previousSelectError = null;
+		} catch (error) {
+			// If select throws, we treat it as an error state
+			const err =
+				error instanceof Error ? error : new Error(String(error));
+			this.previousSelectError = err;
+			this.currentResult = {
+				...this.currentResult,
+				data: undefined,
+				error: err as TError,
+				status: 'error',
+				isPending: false,
+				isLoading: false,
+				isSuccess: false,
+				isError: true,
+				isFetching: false,
+				isRefetching: false,
+			};
+		}
+
+		if (
+			shouldNotify(
+				prevResult,
+				this.currentResult,
+				this.options.notifyOnChangeProps as Array<
+					keyof QueryObserverResult<TSelected, TError>
+				>
+			)
+		) {
+			this.notify();
+		}
+	}
+
+	private notify(): void {
+		if (this.listener) {
+			this.listener(this.currentResult);
+		}
+	}
+}

--- a/packages/query/src/core/query.test.ts
+++ b/packages/query/src/core/query.test.ts
@@ -1,0 +1,214 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { Query } from './query.js';
+
+describe('Query', () => {
+	const createTestQuery = (overrides?: Partial<Parameters<typeof Query.prototype.fetch>[0]>) =>
+		new Query({
+			queryKey: ['test'],
+			queryFn: async () => 'data',
+			...overrides,
+		});
+
+	it('should create with initial state', () => {
+		const query = createTestQuery();
+		expect(query.currentState.status).toBe('pending');
+		expect(query.currentState.fetchStatus).toBe('idle');
+		expect(query.currentState.data).toBeUndefined();
+		expect(query.observerCount).toBe(0);
+	});
+
+	it('should dispatch actions to update state', () => {
+		const query = createTestQuery();
+		query.dispatch({ type: 'success', data: 'hello' });
+		expect(query.currentState.status).toBe('success');
+		expect(query.currentState.data).toBe('hello');
+	});
+
+	it('should track observers', () => {
+		const query = createTestQuery();
+		const observer = { onQueryUpdate: vi.fn() };
+		const unsubscribe = query.addObserver(observer);
+		expect(query.observerCount).toBe(1);
+		unsubscribe();
+		expect(query.observerCount).toBe(0);
+	});
+
+	it('should notify observers on state change', () => {
+		const query = createTestQuery();
+		const observer = { onQueryUpdate: vi.fn() };
+		query.addObserver(observer);
+		query.dispatch({ type: 'success', data: 'hello' });
+		expect(observer.onQueryUpdate).toHaveBeenCalledTimes(1);
+	});
+
+	it('should deduplicate concurrent fetches', async () => {
+		let callCount = 0;
+		const query = new Query({
+			queryKey: ['dedup'],
+			queryFn: async () => {
+				callCount++;
+				await new Promise((r) => setTimeout(r, 20));
+				return 'result';
+			},
+		});
+
+		const [r1, r2] = await Promise.all([query.fetch(), query.fetch()]);
+		expect(callCount).toBe(1);
+		expect(r1).toBe('result');
+		expect(r2).toBe('result');
+	});
+
+	it('should handle fetch success', async () => {
+		const query = createTestQuery();
+		const result = await query.fetch();
+		expect(result).toBe('data');
+		expect(query.currentState.status).toBe('success');
+		expect(query.currentState.fetchCount).toBe(1);
+	});
+
+	it('should handle fetch error', async () => {
+		const query = new Query({
+			queryKey: ['error'],
+			queryFn: async () => {
+				throw new Error('boom');
+			},
+			retry: false,
+		});
+
+		await expect(query.fetch()).rejects.toThrow('boom');
+		expect(query.currentState.status).toBe('error');
+		expect(query.currentState.error?.message).toBe('boom');
+	});
+
+	it('should cancel in-flight fetch', async () => {
+		const query = new Query({
+			queryKey: ['cancel'],
+			queryFn: async ({ signal }) => {
+				await new Promise((_, reject) => {
+					signal.addEventListener('abort', () => {
+						reject(new Error('cancelled'));
+					});
+				});
+				return 'never';
+			},
+			retry: false,
+		});
+
+		const fetchPromise = query.fetch();
+		query.cancel();
+		await expect(fetchPromise).rejects.toThrow('cancelled');
+		expect(query.currentState.fetchStatus).toBe('idle');
+	});
+
+	it('should retry on failure', async () => {
+		let attempts = 0;
+		const query = new Query({
+			queryKey: ['retry'],
+			queryFn: async () => {
+				attempts++;
+				if (attempts < 3) throw new Error('fail');
+				return 'success';
+			},
+			retry: 3,
+			retryDelay: 10,
+		});
+
+		const result = await query.fetch();
+		expect(result).toBe('success');
+		expect(attempts).toBe(3);
+	});
+
+	it('should apply structural sharing on identical data', async () => {
+		const data = { id: 1, nested: { a: 1 } };
+		const query = new Query({
+			queryKey: ['structural'],
+			queryFn: async () => data,
+		});
+
+		await query.fetch();
+		const firstRef = query.currentState.data;
+		await query.fetch();
+		const secondRef = query.currentState.data;
+		expect(secondRef).toBe(firstRef);
+	});
+
+	it('should create new reference on different data', async () => {
+		let count = 0;
+		const query = new Query({
+			queryKey: ['structural-diff'],
+			queryFn: async () => ({ count: ++count }),
+		});
+
+		await query.fetch();
+		const firstRef = query.currentState.data;
+		await query.fetch();
+		const secondRef = query.currentState.data;
+		expect(secondRef).not.toBe(firstRef);
+	});
+
+	it('should timeout long-running queries', async () => {
+		const query = new Query({
+			queryKey: ['timeout'],
+			queryFn: async () => {
+				await new Promise((r) => setTimeout(r, 500));
+				return 'late';
+			},
+			retry: false,
+			timeout: 50,
+		});
+
+		await expect(query.fetch()).rejects.toThrow('timed out');
+	});
+
+	it('should expose snapshot', () => {
+		const query = createTestQuery();
+		const snap = query.snapshot();
+		expect(snap.queryKey).toEqual(['test']);
+		expect(snap.isActive).toBe(false);
+		expect(snap.observerCount).toBe(0);
+	});
+
+	it('should mark stale correctly', () => {
+		const query = new Query({
+			queryKey: ['stale'],
+			queryFn: async () => 'data',
+			staleTime: 100,
+		});
+
+		expect(query.isStale).toBe(true);
+		query.dispatch({ type: 'success', data: 'data' });
+		expect(query.isStale).toBe(false);
+	});
+
+	it('should invalidate query', () => {
+		const query = createTestQuery();
+		query.dispatch({ type: 'success', data: 'data' });
+		expect(query.isStale).toBe(false);
+		query.invalidate();
+		expect(query.isStale).toBe(true);
+	});
+});

--- a/packages/query/src/core/query.ts
+++ b/packages/query/src/core/query.ts
@@ -1,0 +1,373 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import type {
+	QueryKey,
+	QueryState,
+	QueryAction,
+	QueryConfig,
+	QueryFunction,
+	QueryObserver,
+	QuerySnapshot,
+} from './types.js';
+import { deepEqual } from '../utils/index.js';
+
+let queryIdCounter = 0;
+
+const hashKey = (key: QueryKey): string => JSON.stringify(key);
+
+const createInitialState = <TData, TError = Error>(): QueryState<TData, TError> => ({
+	data: undefined,
+	dataUpdatedAt: 0,
+	error: null,
+	errorUpdatedAt: 0,
+	status: 'pending',
+	fetchStatus: 'idle',
+	fetchCount: 0,
+	isInvalidated: false,
+});
+
+const queryReducer = <TData, TError = Error>(
+	state: QueryState<TData, TError>,
+	action: QueryAction<TData, TError>
+): QueryState<TData, TError> => {
+	switch (action.type) {
+		case 'fetch':
+			return {
+				...state,
+				fetchStatus: 'fetching',
+				status: state.data === undefined ? 'pending' : state.status,
+			};
+
+		case 'success': {
+			const nextData = state.data !== undefined && deepEqual(state.data, action.data)
+				? state.data
+				: action.data;
+			return {
+				...state,
+				data: nextData,
+				dataUpdatedAt: Date.now(),
+				error: null,
+				errorUpdatedAt: 0,
+				status: 'success',
+				fetchStatus: 'idle',
+				fetchCount: state.fetchCount + 1,
+				isInvalidated: false,
+			};
+		}
+
+		case 'error':
+			return {
+				...state,
+				error: action.error,
+				errorUpdatedAt: Date.now(),
+				status: 'error',
+				fetchStatus: 'idle',
+				fetchCount: state.fetchCount + 1,
+			};
+
+		case 'invalidate':
+			return {
+				...state,
+				isInvalidated: true,
+			};
+
+		case 'cancel':
+			return {
+				...state,
+				fetchStatus: 'idle',
+			};
+
+		case 'setState':
+			return { ...state, ...action.state };
+
+		default:
+			return state;
+	}
+};
+
+/**
+ * Represents a single query in the cache.
+ * Manages its own state machine, fetch lifecycle, and observer notifications.
+ */
+export class Query<TData = unknown, TError = Error> {
+	readonly queryHash: string;
+	readonly queryKey: QueryKey;
+	options: QueryConfig<TData, TError>;
+
+	private state: QueryState<TData, TError>;
+	private observers: Set<QueryObserver<TData, TError>> = new Set();
+	private abortController: AbortController | null = null;
+	private gcTimeout: ReturnType<typeof setTimeout> | null = null;
+	private promise: Promise<unknown> | null = null;
+	private queryId: number;
+	private fetchId = 0;
+	private cancelledFetchId = 0;
+
+	constructor(options: QueryConfig<TData, TError>) {
+		this.queryKey = options.queryKey;
+		this.queryHash = hashKey(options.queryKey);
+		this.options = options;
+		this.state = createInitialState<TData, TError>();
+		this.queryId = ++queryIdCounter;
+	}
+
+	get id(): number {
+		return this.queryId;
+	}
+
+	get currentState(): QueryState<TData, TError> {
+		return this.state;
+	}
+
+	get observerCount(): number {
+		return this.observers.size;
+	}
+
+	get isActive(): boolean {
+		return this.observers.size > 0;
+	}
+
+	get isFetching(): boolean {
+		return this.state.fetchStatus === 'fetching';
+	}
+
+	get isStale(): boolean {
+		const { staleTime = 0 } = this.options;
+		return (
+			this.state.isInvalidated ||
+			Date.now() - this.state.dataUpdatedAt > staleTime
+		);
+	}
+
+	snapshot(): QuerySnapshot<TData, TError> {
+		return {
+			queryKey: this.queryKey,
+			state: this.state,
+			observerCount: this.observerCount,
+			isActive: this.isActive,
+		};
+	}
+
+	/**
+	 * Subscribe an observer to this query.
+	 * Returns an unsubscribe function.
+	 */
+	addObserver(observer: QueryObserver<TData, TError>): () => void {
+		this.observers.add(observer);
+		this.cancelGc();
+		return () => {
+			this.observers.delete(observer);
+			if (!this.isActive) {
+				this.scheduleGc();
+			}
+		};
+	}
+
+	/**
+	 * Dispatch an action to the state machine and notify observers.
+	 */
+	dispatch(action: QueryAction<TData, TError>): void {
+		const prevState = this.state;
+		this.state = queryReducer(prevState, action);
+
+		if (prevState !== this.state) {
+			this.notifyObservers();
+		}
+	}
+
+	/**
+	 * Set arbitrary state and notify.
+	 */
+	setState(state: Partial<QueryState<TData, TError>>): void {
+		this.dispatch({ type: 'setState', state });
+	}
+
+	/**
+	 * Mark the query as invalidated (stale).
+	 */
+	invalidate(): void {
+		this.dispatch({ type: 'invalidate' });
+	}
+
+	/**
+	 * Cancel the current in-flight fetch.
+	 */
+	cancel(): void {
+		this.cancelledFetchId = this.fetchId;
+		if (this.abortController) {
+			this.abortController.abort();
+			this.abortController = null;
+		}
+		if (this.isFetching) {
+			this.dispatch({ type: 'cancel' });
+		}
+	}
+
+	/**
+	 * Execute the query function.
+	 * Deduplicates concurrent fetches.
+	 */
+	async fetch(): Promise<TData> {
+		if (this.promise) {
+			return this.promise as Promise<TData>;
+		}
+
+		this.cancel();
+		const currentFetchId = ++this.fetchId;
+		this.abortController = new AbortController();
+		this.dispatch({ type: 'fetch' });
+
+		const { queryFn, timeout } = this.options;
+
+		this.promise = this.runWithRetry(
+			queryFn,
+			this.abortController.signal,
+			timeout,
+			currentFetchId
+		);
+
+		try {
+			const data = await this.promise;
+			if (currentFetchId <= this.cancelledFetchId) {
+				// Fetch was cancelled, ignore result
+				return data as TData;
+			}
+			this.dispatch({ type: 'success', data });
+			return data;
+		} catch (error) {
+			if (currentFetchId <= this.cancelledFetchId) {
+				// Fetch was cancelled, ignore error
+				throw error;
+			}
+			const err = error instanceof Error ? error : new Error(String(error));
+			this.dispatch({ type: 'error', error: err as TError });
+			throw err;
+		} finally {
+			this.promise = null;
+			this.abortController = null;
+		}
+	}
+
+	private async runWithRetry(
+		queryFn: QueryFunction<TData>,
+		signal: AbortSignal,
+		timeout: number | undefined,
+		fetchId: number
+	): Promise<TData> {
+		const { retry = 3 } = this.options;
+		const maxRetries =
+			typeof retry === 'number'
+				? retry
+				: retry === true
+					? 3
+					: retry === false
+						? 0
+						: retry.times ?? 3;
+
+		let lastError: Error | undefined;
+
+		for (let attempt = 0; attempt <= maxRetries; attempt++) {
+			if (fetchId <= this.cancelledFetchId) {
+				throw new Error('Query was cancelled');
+			}
+
+			try {
+				if (signal.aborted) {
+					throw new Error('Query was cancelled');
+				}
+
+				const promise = queryFn({ signal });
+
+				if (timeout && timeout > 0) {
+					const timeoutPromise = new Promise<never>((_, reject) => {
+						const timer = setTimeout(() => {
+							reject(new Error(`Query timed out after ${timeout}ms`));
+						}, timeout);
+						signal.addEventListener('abort', () => {
+							clearTimeout(timer);
+							reject(new Error('Query was cancelled'));
+						});
+					});
+
+					return await Promise.race([promise, timeoutPromise]);
+				}
+
+				return await promise;
+			} catch (error) {
+				if (signal.aborted || fetchId <= this.cancelledFetchId) {
+					throw new Error('Query was cancelled');
+				}
+
+				lastError = error instanceof Error ? error : new Error(String(error));
+
+				if (attempt < maxRetries) {
+					const delay = this.calculateRetryDelay(attempt);
+					await sleep(delay);
+				}
+			}
+		}
+
+		throw lastError;
+	}
+
+	private calculateRetryDelay(attempt: number): number {
+		const { retryDelay = 1000 } = this.options;
+		if (typeof retryDelay === 'number') {
+			return retryDelay * Math.pow(2, attempt);
+		}
+		return 1000 * Math.pow(2, attempt);
+	}
+
+	private notifyObservers(): void {
+		for (const observer of this.observers) {
+			observer.onQueryUpdate();
+		}
+	}
+
+	private scheduleGc(): void {
+		const { gcTime = 5 * 60 * 1000 } = this.options;
+		if (gcTime === Infinity || gcTime === 0) return;
+
+		this.gcTimeout = setTimeout(() => {
+			this.destroy();
+		}, gcTime);
+	}
+
+	private cancelGc(): void {
+		if (this.gcTimeout) {
+			clearTimeout(this.gcTimeout);
+			this.gcTimeout = null;
+		}
+	}
+
+	destroy(): void {
+		this.cancel();
+		this.cancelGc();
+		this.observers.clear();
+	}
+}
+
+const sleep = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/query/src/core/types.ts
+++ b/packages/query/src/core/types.ts
@@ -1,0 +1,124 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import type { RetryConfig } from '../execution/index.js';
+
+export type QueryKey = readonly unknown[];
+
+export type QueryStatus = 'pending' | 'success' | 'error';
+
+export type FetchStatus = 'idle' | 'fetching' | 'paused';
+
+/** Query function that receives an AbortSignal and returns a Promise. */
+export type QueryFunction<T> = (context: {
+	signal: AbortSignal;
+}) => Promise<T>;
+
+/** Internal state maintained by the Query class. */
+export interface QueryState<TData = unknown, TError = Error> {
+	readonly data: TData | undefined;
+	readonly dataUpdatedAt: number;
+	readonly error: TError | null;
+	readonly errorUpdatedAt: number;
+	readonly status: QueryStatus;
+	readonly fetchStatus: FetchStatus;
+	readonly fetchCount: number;
+	readonly isInvalidated: boolean;
+}
+
+/** Actions that drive the Query state machine. */
+export type QueryAction<TData = unknown, TError = Error> =
+	| { readonly type: 'fetch' }
+	| { readonly type: 'success'; readonly data: TData }
+	| { readonly type: 'error'; readonly error: TError }
+	| { readonly type: 'invalidate' }
+	| { readonly type: 'cancel' }
+	| { readonly type: 'setState'; readonly state: Partial<QueryState<TData, TError>> };
+
+/** Base options for configuring a Query. */
+export interface QueryConfig<TData = unknown, TError = Error> {
+	readonly queryKey: QueryKey;
+	readonly queryFn: QueryFunction<TData>;
+	readonly staleTime?: number;
+	readonly gcTime?: number;
+	readonly retry?: RetryConfig | number | boolean;
+	readonly retryDelay?: number;
+	readonly timeout?: number;
+}
+
+/** Options specific to a QueryObserver. */
+export interface QueryObserverOptions<
+	TData = unknown,
+	TError = Error,
+	TSelected = TData,
+> extends QueryConfig<TData, TError> {
+	readonly enabled?: boolean;
+	readonly select?: (data: TData) => TSelected;
+	readonly placeholderData?:
+		| TSelected
+		| ((previousData: TSelected | undefined) => TSelected);
+	readonly initialData?: TData | (() => TData);
+	readonly refetchOnWindowFocus?: boolean;
+	readonly refetchOnReconnect?: boolean;
+	readonly refetchInterval?: number | false;
+	readonly notifyOnChangeProps?: Array<keyof QueryObserverResult<TSelected, TError>>;
+	readonly structuralSharing?: boolean;
+}
+
+/** Result object produced by a QueryObserver. */
+export interface QueryObserverResult<TData = unknown, TError = Error> {
+	readonly data: TData | undefined;
+	readonly dataUpdatedAt: number;
+	readonly error: TError | null;
+	readonly errorUpdatedAt: number;
+	readonly status: QueryStatus;
+	readonly fetchStatus: FetchStatus;
+	readonly isPending: boolean;
+	readonly isLoading: boolean;
+	readonly isSuccess: boolean;
+	readonly isError: boolean;
+	readonly isFetching: boolean;
+	readonly isRefetching: boolean;
+	readonly isStale: boolean;
+	readonly isPlaceholderData: boolean;
+	readonly fetchCount: number;
+}
+
+/** Function called when the observer result changes. */
+export type QueryObserverListener<TData = unknown, TError = Error> = (
+	result: QueryObserverResult<TData, TError>
+) => void;
+
+/** Snapshot of a query for external inspection. */
+export interface QuerySnapshot<TData = unknown, TError = Error> {
+	readonly queryKey: QueryKey;
+	readonly state: QueryState<TData, TError>;
+	readonly observerCount: number;
+	readonly isActive: boolean;
+}
+
+/** Interface that the Query class expects from observers. */
+export interface QueryObserver<TData = unknown, TError = Error> {
+	readonly onQueryUpdate: () => void;
+}

--- a/packages/query/src/hooks/useQuery.ts
+++ b/packages/query/src/hooks/useQuery.ts
@@ -22,28 +22,18 @@
  * SOFTWARE.
  */
 
-import { Effect, Fiber, Duration, Exit, Predicate, Option, pipe } from 'effect';
+import { Effect } from 'effect';
 import { signal, computed, type Signal, type ReadonlySignal } from '@effuse/core';
 import {
 	useQueryClient,
 	type QueryOptions,
-	type CacheEntry,
 	type FetchStatus,
 } from '../client/index.js';
-import {
-	buildRetrySchedule,
-	buildRefetchSchedule,
-	type RetryConfig,
-} from '../execution/index.js';
-import { executeQuery } from '../request/index.js';
-import { DEFAULT_STALE_TIME_MS, DEFAULT_TIMEOUT_MS } from '../config/index.js';
-import { TimeoutError } from '../errors/index.js';
-import { deepEqual } from '../utils/index.js';
+import { QueryObserver } from '../core/index.js';
+import type { QueryFunction as CoreQueryFunction } from '../core/types.js';
 
-// Query result status
 export type QueryStatus = 'pending' | 'success' | 'error';
 
-// Query result data and state
 export interface UseQueryResult<T> {
 	readonly data: Signal<T | undefined>;
 	readonly error: Signal<Error | undefined>;
@@ -71,25 +61,36 @@ export interface UseQueryResult<T> {
 	readonly failureReason: Signal<Error | undefined>;
 }
 
-const normalizeRetryConfig = (
-	retry: RetryConfig | number | boolean | undefined
-): RetryConfig | undefined => {
-	if (retry === false) return { times: 0 };
-	if (retry === true) return undefined;
-	if (typeof retry === 'number') return { times: retry };
-	return retry;
+const wrapQueryFn = <T>(
+	queryFn: () => Promise<T> | Effect.Effect<T, Error, never>
+): CoreQueryFunction<T> => {
+	return ({ signal }: { signal: AbortSignal }) => {
+		const result = queryFn();
+
+		if (Effect.isEffect(result)) {
+			// For Effect, run it and return the promise
+			return Effect.runPromise(result).catch((error) => {
+				if (signal.aborted) {
+					throw new Error('Query was cancelled');
+				}
+				throw error;
+			});
+		}
+
+		return result;
+	};
 };
 
-// Reactive query hook
 export const useQuery = <TData>(
 	options: QueryOptions<TData>
 ): UseQueryResult<TData> => {
 	const {
 		queryKey,
 		queryFn,
-		staleTime = DEFAULT_STALE_TIME_MS,
+		staleTime,
+		cacheTime,
 		retry,
-		timeout = DEFAULT_TIMEOUT_MS,
+		timeout,
 		enabled = true,
 		refetchOnWindowFocus = true,
 		refetchOnReconnect = true,
@@ -104,21 +105,19 @@ export const useQuery = <TData>(
 
 	const client = options.client ?? useQueryClient();
 
+	// Signals mirroring the observer result
 	const dataSignal = signal<TData | undefined>(undefined);
 	const errorSignal = signal<Error | undefined>(undefined);
 	const statusSignal = signal<QueryStatus>('pending');
 	const fetchStatusSignal = signal<FetchStatus>('idle');
-
 	const isStaleSignal = signal<boolean>(true);
 	const isPlaceholderDataSignal = signal<boolean>(false);
-
 	const dataUpdatedAtSignal = signal<number | undefined>(undefined);
 	const errorUpdatedAtSignal = signal<number | undefined>(undefined);
-
 	const failureCountSignal = signal<number>(0);
 	const failureReasonSignal = signal<Error | undefined>(undefined);
 
-	// Derived state — automatically reactive via computed()
+	// Derived state
 	const isPendingSignal = computed(() => statusSignal.value === 'pending');
 	const isLoadingSignal = computed(
 		() => statusSignal.value === 'pending' && fetchStatusSignal.value === 'fetching'
@@ -130,256 +129,146 @@ export const useQuery = <TData>(
 		() => dataSignal.value !== undefined && fetchStatusSignal.value === 'fetching'
 	);
 
-	let activeFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
-	let refetchIntervalFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
-	let isInternalUpdate = false;
+	// Get or create the query
+	const query = client.getQuery<TData, Error>({
+		queryKey,
+		queryFn: wrapQueryFn(queryFn),
+		staleTime,
+		gcTime: cacheTime,
+		retry,
+		timeout,
+	});
 
-	const cleanupFns: Array<() => void> = [];
+	// Create the observer
+	const observer = new QueryObserver(query, {
+		queryKey,
+		queryFn: wrapQueryFn(queryFn),
+		staleTime,
+		gcTime: cacheTime,
+		retry,
+		timeout,
+		enabled,
+		select,
+		placeholderData,
+		initialData,
+		refetchOnWindowFocus,
+		refetchOnReconnect,
+		refetchInterval,
+	});
 
-	const buildFetchEffect = (): Effect.Effect<TData, Error, never> => {
-		const retryConfig = normalizeRetryConfig(retry);
-		const schedule = buildRetrySchedule(retryConfig);
+	// Sync signals from observer result
+	const syncResult = (result: ReturnType<typeof observer.getCurrentResult>): void => {
+		dataSignal.value = result.data as TData | undefined;
+		errorSignal.value = result.error ?? undefined;
+		statusSignal.value = result.status;
+		fetchStatusSignal.value = result.fetchStatus;
+		isStaleSignal.value = result.isStale;
+		isPlaceholderDataSignal.value = result.isPlaceholderData;
+		dataUpdatedAtSignal.value = result.dataUpdatedAt || undefined;
+		errorUpdatedAtSignal.value = result.errorUpdatedAt || undefined;
 
-		let effect: Effect.Effect<TData, Error, never> = executeQuery(
-			queryKey,
-			queryFn
-		);
+		if (result.isError && result.error) {
+			failureCountSignal.value += 1;
+			failureReasonSignal.value = result.error;
+		} else if (result.isSuccess) {
+			failureCountSignal.value = 0;
+			failureReasonSignal.value = undefined;
+		}
 
-		effect = effect.pipe(
-			Effect.timeoutFail({
-				duration: Duration.millis(timeout),
-				onTimeout: () => new TimeoutError({ durationMs: timeout }),
-			})
-		);
-
-		if (!Predicate.isNotNullable(retryConfig) || retryConfig.times !== 0) {
-			effect = effect.pipe(
-				Effect.retry(schedule),
-				Effect.tapError((error) =>
-					Effect.sync(() => {
-						failureCountSignal.value += 1;
-						failureReasonSignal.value = error;
-					})
-				)
+		if (result.isSuccess && onSuccess) {
+			onSuccess(result.data as TData);
+		}
+		if (result.isError && onError && result.error) {
+			onError(result.error);
+		}
+		if (onSettled) {
+			onSettled(
+				result.isSuccess ? (result.data as TData) : undefined,
+				result.isError ? result.error : undefined
 			);
 		}
-
-		if (select) {
-			effect = effect.pipe(Effect.map(select));
-		}
-
-		return effect;
 	};
 
-	const executeFetch = async (): Promise<void> => {
-		if (activeFiber) {
-			Effect.runFork(Fiber.interrupt(activeFiber));
-			activeFiber = null;
-		}
+	// Initial sync
+	syncResult(observer.getCurrentResult());
 
-		fetchStatusSignal.value = 'fetching';
+	// Subscribe to changes
+	const unsubscribe = observer.subscribe((result) => {
+		syncResult(result);
+	});
 
-		const effect = buildFetchEffect();
-
-		const fiber = Effect.runFork(
-			effect.pipe(
-				Effect.tap((data) =>
-					Effect.sync(() => {
-						const current = dataSignal.value;
-						const shouldUpdate =
-							current === undefined || !deepEqual(current, data);
-
-						if (shouldUpdate) {
-							const entry: CacheEntry<TData> = {
-								data,
-								dataUpdatedAt: Date.now(),
-								status: 'success',
-								fetchCount:
-									pipe(
-										Option.fromNullable(client.get<TData>(queryKey)),
-										Option.flatMap((e) => Option.fromNullable(e.fetchCount)),
-										Option.getOrElse(() => 0)
-									) + 1,
-							};
-							isInternalUpdate = true;
-							client.set(queryKey, entry);
-							isInternalUpdate = false;
-							dataSignal.value = data;
-						}
-
-						errorSignal.value = undefined;
-						statusSignal.value = 'success';
-						fetchStatusSignal.value = 'idle';
-						dataUpdatedAtSignal.value = Date.now();
-						isPlaceholderDataSignal.value = false;
-						failureCountSignal.value = 0;
-						failureReasonSignal.value = undefined;
-						isStaleSignal.value = client.isStale(queryKey, staleTime);
-
-						if (Predicate.isNotNullable(onSuccess)) {
-							onSuccess(data);
-						}
-						if (Predicate.isNotNullable(onSettled)) {
-							onSettled(data, undefined);
-						}
-					})
-				),
-				Effect.catchAll((error: Error) =>
-					Effect.sync(() => {
-						const entry: CacheEntry<TData> = {
-							data: dataSignal.value as TData,
-							dataUpdatedAt: Date.now(),
-							status: 'error',
-							error,
-							fetchCount:
-								pipe(
-									Option.fromNullable(client.get<TData>(queryKey)),
-									Option.flatMap((e) => Option.fromNullable(e.fetchCount)),
-									Option.getOrElse(() => 0)
-								) + 1,
-						};
-						isInternalUpdate = true;
-						client.set(queryKey, entry);
-						isInternalUpdate = false;
-
-						errorSignal.value = error;
-						statusSignal.value = 'error';
-						fetchStatusSignal.value = 'idle';
-						errorUpdatedAtSignal.value = Date.now();
-						isStaleSignal.value = client.isStale(queryKey, staleTime);
-
-						if (Predicate.isNotNullable(onError)) {
-							onError(error);
-						}
-						if (Predicate.isNotNullable(onSettled)) {
-							onSettled(undefined, error);
-						}
-					})
-				),
-				Effect.scoped
-			)
-		);
-
-		activeFiber = fiber;
-
-		const exit = await Effect.runPromiseExit(Fiber.join(fiber));
-		if (Exit.isFailure(exit)) {
-			fetchStatusSignal.value = 'idle';
-			isStaleSignal.value = client.isStale(queryKey, staleTime);
-		}
-	};
-
-	const cancel = (): void => {
-		if (activeFiber) {
-			Effect.runFork(Fiber.interrupt(activeFiber));
-			activeFiber = null;
-		}
-		if (refetchIntervalFiber) {
-			Effect.runFork(Fiber.interrupt(refetchIntervalFiber));
-			refetchIntervalFiber = null;
-		}
-		fetchStatusSignal.value = 'idle';
-		isStaleSignal.value = client.isStale(queryKey, staleTime);
-	};
-
-	const dispose = (): void => {
-		cancel();
-		for (const fn of cleanupFns) {
-			fn();
-		}
-	};
-
-	const refetch = async (): Promise<void> => {
-		if (!enabled) return;
-		await executeFetch();
-	};
-
-	const cached = client.get<TData>(queryKey);
-	if (cached) {
-		dataSignal.value = cached.data;
-
-		if (cached.status === 'success') {
-			statusSignal.value = 'success';
-		} else if (cached.status === 'error') {
-			statusSignal.value = 'error';
-		} else {
-			statusSignal.value = 'pending';
-		}
-		dataUpdatedAtSignal.value = cached.dataUpdatedAt;
-		if (cached.error) {
-			errorSignal.value = cached.error as Error;
-		}
-		isStaleSignal.value = client.isStale(queryKey, staleTime);
-	} else if (initialData !== undefined) {
-		const initial =
-			typeof initialData === 'function'
-				? (initialData as () => TData)()
-				: initialData;
-		dataSignal.value = initial;
-		statusSignal.value = 'success';
-		dataUpdatedAtSignal.value = Date.now();
-		isStaleSignal.value = client.isStale(queryKey, staleTime);
-	} else if (placeholderData !== undefined) {
-		const placeholder =
-			typeof placeholderData === 'function'
-				? (placeholderData as (previousData: TData | undefined) => TData)(
-						undefined
-					)
-				: placeholderData;
-		dataSignal.value = placeholder;
-		isPlaceholderDataSignal.value = true;
+	// Refetch if stale and enabled
+	if (enabled && query.isStale) {
+		query.fetch().catch(() => {
+			// Errors are handled by the observer
+		});
 	}
 
-	const unsubscribe = client.subscribe(queryKey, () => {
-		if (isInternalUpdate) return;
-		isStaleSignal.value = true;
-		if (enabled) {
-			executeFetch();
-		}
-	});
-	cleanupFns.push(unsubscribe);
+	// Window focus refetch
+	const cleanupFns: Array<() => void> = [unsubscribe];
 
 	if (refetchOnWindowFocus && typeof window !== 'undefined') {
 		const handleFocus = (): void => {
-			if (enabled && client.isStale(queryKey, staleTime)) {
-				executeFetch();
+			if (enabled && query.isStale) {
+				query.fetch().catch(() => {
+					// Errors handled by observer
+				});
 			}
 		};
 		window.addEventListener('focus', handleFocus);
 		cleanupFns.push(() => window.removeEventListener('focus', handleFocus));
 	}
 
+	// Reconnect refetch
 	if (refetchOnReconnect && typeof window !== 'undefined') {
 		const handleOnline = (): void => {
-			if (enabled && client.isStale(queryKey, staleTime)) {
-				executeFetch();
+			if (enabled && query.isStale) {
+				query.fetch().catch(() => {
+					// Errors handled by observer
+				});
 			}
 		};
 		window.addEventListener('online', handleOnline);
 		cleanupFns.push(() => window.removeEventListener('online', handleOnline));
 	}
 
+	// Refetch interval
+	let intervalId: ReturnType<typeof setInterval> | null = null;
 	if (refetchInterval !== false && refetchInterval > 0) {
-		const intervalEffect = Effect.repeat(
-			Effect.sync(() => {
-				if (enabled) {
-					executeFetch();
-				}
-			}),
-			buildRefetchSchedule(refetchInterval)
-		);
-		refetchIntervalFiber = Effect.runFork(intervalEffect);
+		intervalId = setInterval(() => {
+			if (enabled) {
+				query.fetch().catch(() => {
+					// Errors handled by observer
+				});
+			}
+		}, refetchInterval);
 		cleanupFns.push(() => {
-			if (refetchIntervalFiber) {
-				Effect.runFork(Fiber.interrupt(refetchIntervalFiber));
-				refetchIntervalFiber = null;
+			if (intervalId) {
+				clearInterval(intervalId);
+				intervalId = null;
 			}
 		});
 	}
 
-	if (enabled && client.isStale(queryKey, staleTime)) {
-		executeFetch();
-	}
+	const cancel = (): void => {
+		query.cancel();
+	};
+
+	const dispose = (): void => {
+		observer.destroy();
+		for (const fn of cleanupFns) {
+			fn();
+		}
+		if (intervalId) {
+			clearInterval(intervalId);
+			intervalId = null;
+		}
+	};
+
+	const refetch = async (): Promise<void> => {
+		if (!enabled) return;
+		await query.fetch();
+	};
 
 	return {
 		data: dataSignal,

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -112,3 +112,19 @@ export {
 } from './errors/index.js';
 
 export type { RetryConfig, BackoffStrategy } from './execution/index.js';
+
+export { Query, QueryObserver, QueryCache } from './core/index.js';
+
+export type {
+	QueryKey as CoreQueryKey,
+	QueryStatus as CoreQueryStatus,
+	FetchStatus as CoreFetchStatus,
+	QueryFunction as CoreQueryFunction,
+	QueryState,
+	QueryAction,
+	QueryConfig,
+	QueryObserverOptions,
+	QueryObserverResult,
+	QueryObserverListener,
+	QuerySnapshot,
+} from './core/index.js';


### PR DESCRIPTION
## Summary

Closes #154

Implements a dedicated observer layer between the cache (`Query`) and the UI (`useQuery`). Built from first principles — no external library code.

## Architecture

```
useQuery → QueryObserver → Query → QueryCache
                ↑___________|
           (multiple observers per query)
```

## Changes

- **`Query` class** — dispatch/reducer state machine with actions: `fetch`, `success`, `error`, `invalidate`, `cancel`. Manages queryFn execution with `AbortSignal`, deduplicates concurrent fetches, handles retry with exponential backoff.
- **`QueryObserver`** — bridges one `Query` to one UI subscriber. Computes result from Query state + observer options. Memoizes `select` (only re-runs when source data changes). Supports `notifyOnChangeProps` for granular notifications. Handles `placeholderData` and `initialData` at observer level.
- **`QueryCache`** — maps query keys → `Query` instances. Creates on demand, supports garbage collection.
- **Refactored `useQuery`** — now creates a `QueryObserver`, subscribes to it, and syncs signals on change. Much simpler — fetch logic moved into `Query`.
- **Structural sharing** — `queryReducer` uses `deepEqual` to preserve references when data hasn't changed.
- **AbortSignal support** — `Query` creates an `AbortController` per fetch and passes `signal` to `queryFn`.
- **Backward compatibility** — `client.getQuery()` seeds new `Query` instances from the legacy cache if data exists.
- **134 tests passing** (38 new core architecture tests)

## Verification

- [x] All existing tests pass
- [x] New tests for `Query` state machine, fetch, cancel, retry, structural sharing, timeout
- [x] New tests for `QueryObserver` select memoization, initialData, placeholderData, change tracking, error handling
- [x] New tests for `QueryCache` getOrCreate, sharing, removal
- [x] Zero Effect types in public API surface