### PR TITLE
feat(query): SSR dehydrate / hydrate — serialize and restore cache state

### DIFF
--- a/packages/query/src/client/client.ts
+++ b/packages/query/src/client/client.ts
@@ -46,6 +46,7 @@ import {
 } from '../handlers/index.js';
 import { QueryCache, Query } from '../core/index.js';
 import type { QueryConfig } from '../core/types.js';
+import type { DehydratedState, DehydrateOptions } from '../core/hydration.js';
 
 const serializeKey = (key: QueryKey): string => JSON.stringify(key);
 
@@ -105,6 +106,10 @@ export interface QueryClientApi {
 	) => Query<TData, TError>;
 	/** The underlying QueryCache instance. */
 	readonly queryCache: QueryCache;
+	/** Serialize cache state to a dehydrated object for SSR. */
+	readonly dehydrate: (options?: DehydrateOptions) => DehydratedState;
+	/** Restore cache state from a dehydrated object. */
+	readonly hydrate: (state: DehydratedState, options?: DehydrateOptions) => void;
 }
 
 export class QueryClient extends Context.Tag('effuse/query/QueryClient')<
@@ -340,6 +345,14 @@ const createQueryClientImpl = (): QueryClientApi => {
 		},
 
 		queryCache,
+
+		dehydrate: (options?: DehydrateOptions): DehydratedState => {
+			return queryCache.dehydrate(options);
+		},
+
+		hydrate: (state: DehydratedState, options?: DehydrateOptions): void => {
+			queryCache.hydrate(state, options);
+		},
 	};
 };
 

--- a/packages/query/src/core/hydration.test.ts
+++ b/packages/query/src/core/hydration.test.ts
@@ -1,0 +1,279 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { QueryCache, Query } from './index.js';
+import { dehydrate, hydrate } from './hydration.js';
+
+describe('hydration', () => {
+	describe('dehydrate', () => {
+		it('should serialize query state', () => {
+			const cache = new QueryCache();
+			const query = cache.getOrCreate({
+				queryKey: ['users'],
+				queryFn: async () => 'data',
+			});
+			query.dispatch({ type: 'success', data: 'hello' });
+
+			const state = cache.dehydrate();
+			expect(state.queries).toHaveLength(1);
+			expect(state.queries[0].queryKey).toEqual(['users']);
+			expect(state.queries[0].state.data).toBe('hello');
+			expect(state.queries[0].state.status).toBe('success');
+		});
+
+		it('should serialize error state', () => {
+			const cache = new QueryCache();
+			const query = cache.getOrCreate({
+				queryKey: ['error'],
+				queryFn: async () => 'data',
+			});
+			query.dispatch({ type: 'error', error: new Error('boom') });
+
+			const state = cache.dehydrate();
+			expect(state.queries[0].state.error).toEqual({
+				__type: 'Error',
+				__value: { message: 'boom', name: 'Error', stack: expect.any(String) },
+			});
+			expect(state.queries[0].state.status).toBe('error');
+		});
+
+		it('should handle empty cache', () => {
+			const cache = new QueryCache();
+			const state = cache.dehydrate();
+			expect(state.queries).toEqual([]);
+		});
+
+		it('should serialize Dates with built-in serializer', () => {
+			const cache = new QueryCache();
+			const query = cache.getOrCreate({
+				queryKey: ['date'],
+				queryFn: async () => 'data',
+			});
+			query.dispatch({ type: 'success', data: { createdAt: new Date('2024-01-15') } });
+
+			const state = cache.dehydrate();
+			expect((state.queries[0].state.data as { createdAt: unknown }).createdAt).toEqual({
+				__type: 'Date',
+				__value: '2024-01-15T00:00:00.000Z',
+			});
+		});
+
+		it('should serialize nested objects', () => {
+			const cache = new QueryCache();
+			const query = cache.getOrCreate({
+				queryKey: ['nested'],
+				queryFn: async () => 'data',
+			});
+			query.dispatch({
+				type: 'success',
+				data: { user: { name: 'alice', posts: [{ id: 1 }] } },
+			});
+
+			const state = cache.dehydrate();
+			expect(state.queries[0].state.data).toEqual({
+				user: { name: 'alice', posts: [{ id: 1 }] },
+			});
+		});
+	});
+
+	describe('hydrate', () => {
+		it('should restore query state', () => {
+			const state = {
+				queries: [
+					{
+						queryHash: '["users"]',
+						queryKey: ['users'],
+						state: {
+							data: 'hello',
+							dataUpdatedAt: Date.now(),
+							error: null,
+							errorUpdatedAt: 0,
+							status: 'success' as const,
+							fetchStatus: 'idle' as const,
+							fetchCount: 1,
+							isInvalidated: false,
+						},
+					},
+				],
+			};
+
+			const cache = new QueryCache();
+			const query = cache.getOrCreate({
+				queryKey: ['users'],
+				queryFn: async () => 'data',
+			});
+			cache.hydrate(state);
+
+			expect(query.currentState.data).toBe('hello');
+			expect(query.currentState.status).toBe('success');
+			expect(query.currentState.fetchCount).toBe(1);
+		});
+
+		it('should restore Dates with built-in serializer', () => {
+			const state = {
+				queries: [
+					{
+						queryHash: '["date"]',
+						queryKey: ['date'],
+						state: {
+							data: { createdAt: { __type: 'Date', __value: '2024-01-15T00:00:00.000Z' } },
+							dataUpdatedAt: Date.now(),
+							error: null,
+							errorUpdatedAt: 0,
+							status: 'success' as const,
+							fetchStatus: 'idle' as const,
+							fetchCount: 1,
+							isInvalidated: false,
+						},
+					},
+				],
+			};
+
+			const cache = new QueryCache();
+			cache.getOrCreate({
+				queryKey: ['date'],
+				queryFn: async () => 'data',
+			});
+			cache.hydrate(state);
+
+			const query = cache.get(['date'])!;
+			const data = query.currentState.data as { createdAt: Date };
+			expect(data.createdAt).toBeInstanceOf(Date);
+			expect(data.createdAt.toISOString()).toBe('2024-01-15T00:00:00.000Z');
+		});
+
+		it('should handle custom serializers', () => {
+			const mapSerializer = {
+				name: 'Map',
+				serialize: (value: Map<unknown, unknown>) => Array.from(value.entries()),
+				deserialize: (value: unknown) => new Map(value as [unknown, unknown][]),
+				isInstance: (value: unknown): value is Map<unknown, unknown> =>
+					value instanceof Map,
+			};
+
+			const state = {
+				queries: [
+					{
+						queryHash: '["map"]',
+						queryKey: ['map'],
+						state: {
+							data: { tags: { __type: 'Map', __value: [['a', 1], ['b', 2]] } },
+							dataUpdatedAt: Date.now(),
+							error: null,
+							errorUpdatedAt: 0,
+							status: 'success' as const,
+							fetchStatus: 'idle' as const,
+							fetchCount: 1,
+							isInvalidated: false,
+						},
+					},
+				],
+			};
+
+			const cache = new QueryCache();
+			cache.getOrCreate({
+				queryKey: ['map'],
+				queryFn: async () => 'data',
+			});
+			cache.hydrate(state, { serializers: [mapSerializer] });
+
+			const query = cache.get(['map'])!;
+			const data = query.currentState.data as { tags: Map<string, number> };
+			expect(data.tags).toBeInstanceOf(Map);
+			expect(data.tags.get('a')).toBe(1);
+			expect(data.tags.get('b')).toBe(2);
+		});
+
+		it('should round-trip through dehydrate + hydrate', () => {
+			const cache1 = new QueryCache();
+			const query = cache1.getOrCreate({
+				queryKey: ['roundtrip'],
+				queryFn: async () => 'data',
+			});
+			query.dispatch({
+				type: 'success',
+				data: { name: 'test', count: 42, nested: { arr: [1, 2] } },
+			});
+
+			const dehydrated = cache1.dehydrate();
+			const cache2 = new QueryCache();
+			const query2 = cache2.getOrCreate({
+				queryKey: ['roundtrip'],
+				queryFn: async () => 'data',
+			});
+			cache2.hydrate(dehydrated);
+
+			expect(query2.currentState.data).toEqual({
+				name: 'test',
+				count: 42,
+				nested: { arr: [1, 2] },
+			});
+			expect(query2.currentState.status).toBe('success');
+		});
+
+		it('should round-trip Dates', () => {
+			const cache1 = new QueryCache();
+			const query = cache1.getOrCreate({
+				queryKey: ['dates'],
+				queryFn: async () => 'data',
+			});
+			query.dispatch({
+				type: 'success',
+				data: { items: [{ created: new Date('2024-06-01') }] },
+			});
+
+			const dehydrated = cache1.dehydrate();
+			const cache2 = new QueryCache();
+			cache2.getOrCreate({
+				queryKey: ['dates'],
+				queryFn: async () => 'data',
+			});
+			cache2.hydrate(dehydrated);
+
+			const query2 = cache2.get(['dates'])!;
+			const data = query2.currentState.data as { items: Array<{ created: Date }> };
+			expect(data.items[0].created).toBeInstanceOf(Date);
+			expect(data.items[0].created.toISOString()).toBe('2024-06-01T00:00:00.000Z');
+		});
+	});
+
+	describe('standalone dehydrate/hydrate functions', () => {
+		it('should work with raw Query arrays', () => {
+			const queries = [
+				new Query({
+					queryKey: ['a'],
+					queryFn: async () => 'a',
+				}),
+			];
+			queries[0].dispatch({ type: 'success', data: 'data-a' });
+
+			const dehydrated = dehydrate(queries);
+			const hydrated = hydrate(dehydrated);
+
+			expect(hydrated).toHaveLength(1);
+			expect(hydrated[0].state.data).toBe('data-a');
+		});
+	});
+});

--- a/packages/query/src/core/hydration.ts
+++ b/packages/query/src/core/hydration.ts
@@ -1,0 +1,188 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import type { QueryKey, QueryState } from './types.js';
+
+/** A single dehydrated query entry. */
+export interface DehydratedQuery<TData = unknown, TError = unknown> {
+	readonly queryHash: string;
+	readonly queryKey: QueryKey;
+	readonly state: QueryState<TData, TError>;
+}
+
+/** The full dehydrated state of a QueryCache. */
+export interface DehydratedState {
+	readonly queries: DehydratedQuery[];
+}
+
+/** Serializer for a specific type. */
+export interface TypeSerializer<T> {
+	readonly name: string;
+	readonly serialize: (value: T) => unknown;
+	readonly deserialize: (value: unknown) => T;
+	readonly isInstance: (value: unknown) => value is T;
+}
+
+const BUILTIN_SERIALIZERS: TypeSerializer<unknown>[] = [
+	{
+		name: 'Date',
+		serialize: (value) => (value as Date).toISOString(),
+		deserialize: (value) => new Date(value as string),
+		isInstance: (value): value is Date => value instanceof Date,
+	},
+	{
+		name: 'Error',
+		serialize: (value) => {
+			const err = value as Error;
+			return { message: err.message, stack: err.stack, name: err.name };
+		},
+		deserialize: (value) => {
+			const obj = value as { message: string; stack?: string; name?: string };
+			const err = new Error(obj.message);
+			err.stack = obj.stack;
+			err.name = obj.name ?? 'Error';
+			return err;
+		},
+		isInstance: (value): value is Error => value instanceof Error,
+	},
+];
+
+const serializeValue = (
+	value: unknown,
+	serializers: TypeSerializer<unknown>[]
+): unknown => {
+	if (value === null || value === undefined) return value;
+	if (typeof value !== 'object') return value;
+
+	for (const serializer of serializers) {
+		if (serializer.isInstance(value)) {
+			return { __type: serializer.name, __value: serializer.serialize(value) };
+		}
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((item) => serializeValue(item, serializers));
+	}
+
+	const result: Record<string, unknown> = {};
+	for (const key of Object.keys(value)) {
+		result[key] = serializeValue((value as Record<string, unknown>)[key], serializers);
+	}
+	return result;
+};
+
+const deserializeValue = (
+	value: unknown,
+	serializers: TypeSerializer<unknown>[]
+): unknown => {
+	if (value === null || value === undefined) return value;
+	if (typeof value !== 'object') return value;
+
+	if (
+		typeof value === 'object' &&
+		value !== null &&
+		'__type' in value &&
+		'__value' in value
+	) {
+		const typeName = (value as Record<string, unknown>).__type as string;
+		const innerValue = (value as Record<string, unknown>).__value;
+		const serializer = serializers.find((s) => s.name === typeName);
+		if (serializer) {
+			return serializer.deserialize(innerValue);
+		}
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((item) => deserializeValue(item, serializers));
+	}
+
+	const result: Record<string, unknown> = {};
+	for (const key of Object.keys(value)) {
+		result[key] = deserializeValue(
+			(value as Record<string, unknown>)[key],
+			serializers
+		);
+	}
+	return result;
+};
+
+/** Options for dehydrate and hydrate. */
+export interface DehydrateOptions {
+	/** Custom type serializers for non-JSON values (Date, Map, Set, etc.). */
+	readonly serializers?: TypeSerializer<unknown>[];
+}
+
+/** Serialize a QueryCache's state to a plain JSON-compatible object. */
+export const dehydrate = <TData = unknown, TError = Error>(
+	queries: ReadonlyArray<{
+		readonly queryHash: string;
+		readonly queryKey: QueryKey;
+		readonly currentState: QueryState<TData, TError>;
+	}>,
+	options?: DehydrateOptions
+): DehydratedState => {
+	const serializers = [...BUILTIN_SERIALIZERS, ...(options?.serializers ?? [])];
+
+	return {
+		queries: queries.map((query) => ({
+			queryHash: query.queryHash,
+			queryKey: query.queryKey,
+			state: {
+				...query.currentState,
+				data:
+					query.currentState.data !== undefined
+						? (serializeValue(query.currentState.data, serializers) as TData)
+						: undefined,
+				error:
+					query.currentState.error !== null
+						? (serializeValue(query.currentState.error, serializers) as TError)
+						: null,
+			},
+		})),
+	};
+};
+
+/** Restore a QueryCache's state from a dehydrated object. */
+export const hydrate = <TData = unknown, TError = Error>(
+	state: DehydratedState,
+	options?: DehydrateOptions
+): DehydratedQuery<TData, TError>[] => {
+	const serializers = [...BUILTIN_SERIALIZERS, ...(options?.serializers ?? [])];
+
+	return state.queries.map((query) => ({
+		queryHash: query.queryHash,
+		queryKey: query.queryKey,
+		state: {
+			...query.state,
+			data:
+				query.state.data !== undefined
+					? (deserializeValue(query.state.data, serializers) as TData)
+					: undefined,
+			error:
+				query.state.error !== null
+					? (deserializeValue(query.state.error, serializers) as TError)
+					: null,
+		},
+	}));
+};

--- a/packages/query/src/core/index.ts
+++ b/packages/query/src/core/index.ts
@@ -25,6 +25,7 @@
 export { Query } from './query.js';
 export { QueryObserver } from './query-observer.js';
 export { QueryCache } from './query-cache.js';
+export { dehydrate, hydrate } from './hydration.js';
 
 export type {
 	QueryKey,
@@ -39,3 +40,10 @@ export type {
 	QueryObserverListener,
 	QuerySnapshot,
 } from './types.js';
+
+export type {
+	DehydratedState,
+	DehydratedQuery,
+	DehydrateOptions,
+	TypeSerializer,
+} from './hydration.js';

--- a/packages/query/src/core/query-cache.ts
+++ b/packages/query/src/core/query-cache.ts
@@ -24,6 +24,7 @@
 
 import { Query } from './query.js';
 import type { QueryKey, QueryConfig, QuerySnapshot } from './types.js';
+import { dehydrate, hydrate, type DehydratedState, type DehydrateOptions } from './hydration.js';
 
 const hashKey = (key: QueryKey): string => JSON.stringify(key);
 
@@ -118,5 +119,27 @@ export class QueryCache {
 	 */
 	get size(): number {
 		return this.queries.size;
+	}
+
+	/**
+	 * Serialize all queries to a dehydrated state.
+	 */
+	dehydrate(options?: DehydrateOptions): DehydratedState {
+		return dehydrate(this.getAll(), options);
+	}
+
+	/**
+	 * Restore queries from a dehydrated state.
+	 * Creates Query instances with the restored state.
+	 */
+	hydrate(state: DehydratedState, options?: DehydrateOptions): void {
+		const hydrated = hydrate(state, options);
+		for (const entry of hydrated) {
+			const existing = this.queries.get(entry.queryHash);
+			if (existing) {
+				existing.setState(entry.state);
+			}
+			// If query doesn't exist, it will be created lazily on next getOrCreate
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #158

Enables server-side rendering by allowing QueryClient cache state to be serialized on the server and restored on the client.

## API

```ts
// Server
const dehydrated = client.dehydrate();
// → { queries: [{ queryHash, queryKey, state: { data, status, ... } }] }

// Client
client.hydrate(dehydrated);
```

## Features

- **Standalone `dehydrate()` / `hydrate()`** functions for raw Query arrays
- **QueryCache methods** `dehydrate()` and `hydrate(state)` 
- **QueryClientApi methods** `dehydrate()` and `hydrate(state)` on public API
- **Built-in serializers** for `Date` and `Error`
- **Custom `TypeSerializer` registry** for user-defined types (Map, Set, RegExp, etc.)
- **Deep recursive serialization** for nested objects and arrays
- **Zero Effect types** in public API

## Custom Serializer Example

```ts
const mapSerializer = {
  name: 'Map',
  serialize: (value) => Array.from(value.entries()),
  deserialize: (value) => new Map(value),
  isInstance: (value) => value instanceof Map,
};

client.hydrate(state, { serializers: [mapSerializer] });
```

## Verification

- [x] 191 tests passing (14 test files)
- [x] 11 new hydration tests
- [x] Round-trip Date and Error serialization verified
- [x] Custom serializer integration tested