### PR TITLE
feat(query): multi-key optimistic mutations with selective invalidation

### DIFF
--- a/packages/query/src/hooks/index.ts
+++ b/packages/query/src/hooks/index.ts
@@ -31,6 +31,7 @@ export type {
 	MutationStatus,
 	MutateOptions,
 	OptimisticMutationOptions,
+	OptimisticQueryConfig,
 } from './useMutation.js';
 
 export { useQueries, useCombinedQueries } from './useQueries.js';

--- a/packages/query/src/hooks/useMutation.ts
+++ b/packages/query/src/hooks/useMutation.ts
@@ -130,9 +130,6 @@ export const useMutation = <TData, TVariables = void, TContext = unknown>(
 	} = options;
 
 	// Resolved for consistency with other hooks; mutation cache integration is #147
-	const _client = options.client ?? useQueryClient();
-	void _client;
-
 	const dataSignal = signal<TData | undefined>(undefined);
 	const errorSignal = signal<Error | undefined>(undefined);
 	const statusSignal = signal<MutationStatus>('idle');
@@ -343,43 +340,84 @@ export const useMutation = <TData, TVariables = void, TContext = unknown>(
 	};
 };
 
-// Optimistic update hook
-export const useOptimisticMutation = <TData, TVariables>(options: {
-	mutationFn: (variables: TVariables) => Promise<TData>;
-	queryKey: QueryKey;
-	optimisticUpdate: (
+// Per-query optimistic update config
+export interface OptimisticQueryConfig<TData, TVariables> {
+	readonly queryKey: QueryKey;
+	readonly optimisticUpdate: (
 		variables: TVariables,
 		current: TData | undefined
 	) => TData;
-	timeout?: number;
-	client?: import('../client/client.js').QueryClientApi;
-}): UseMutationResult<TData, TVariables, CacheEntry<TData> | undefined> => {
+}
+
+// Options for optimistic mutation
+export interface OptimisticMutationOptions<TData, TVariables> {
+	readonly mutationFn: (variables: TVariables) => Promise<TData>;
+	/** Queries to optimistically update. */
+	readonly queries: ReadonlyArray<OptimisticQueryConfig<TData, TVariables>>;
+	/** Keys to invalidate after successful mutation. */
+	readonly invalidateKeys?: ReadonlyArray<QueryKey>;
+	readonly timeout?: number;
+	readonly client?: import('../client/client.js').QueryClientApi;
+}
+
+interface OptimisticContext<TData> {
+	readonly snapshots: ReadonlyArray<{
+		readonly queryKey: QueryKey;
+		readonly snapshot: CacheEntry<TData> | undefined;
+	}>;
+}
+
+// Optimistic update hook
+export const useOptimisticMutation = <TData, TVariables>(
+	options: OptimisticMutationOptions<TData, TVariables>
+): UseMutationResult<TData, TVariables, OptimisticContext<TData>> => {
 	const {
 		mutationFn,
-		queryKey,
-		optimisticUpdate,
+		queries,
+		invalidateKeys,
 		timeout = DEFAULT_TIMEOUT_MS,
 	} = options;
 	const client = options.client ?? useQueryClient();
 
-	return useMutation<TData, TVariables, CacheEntry<TData> | undefined>({
+	return useMutation<TData, TVariables, OptimisticContext<TData>>({
 		mutationFn,
 		timeout,
 		onMutate: (variables) => {
-			const snapshot = client.getSnapshot<TData>(queryKey);
+			const snapshots = queries.map((config) => {
+				const snapshot = client.getSnapshot<TData>(config.queryKey);
 
-			const existing = client.get<TData>(queryKey);
-			const currentData = Predicate.isNotNullable(existing)
-				? existing.data
-				: undefined;
-			const optimisticData = optimisticUpdate(variables, currentData);
-			client.setOptimistic(queryKey, optimisticData);
+				const existing = client.get<TData>(config.queryKey);
+				const currentData = Predicate.isNotNullable(existing)
+					? existing.data
+					: undefined;
+				const optimisticData = config.optimisticUpdate(
+					variables,
+					currentData
+				);
+				client.setOptimistic(config.queryKey, optimisticData);
 
-			return snapshot;
+				return { queryKey: config.queryKey, snapshot };
+			});
+
+			return { snapshots };
 		},
 		onError: (_error, _variables, context) => {
 			if (context) {
-				client.rollback(queryKey, context);
+				for (const entry of context.snapshots) {
+					if (entry.snapshot) {
+						client.rollback(entry.queryKey, entry.snapshot);
+					} else {
+						// No prior snapshot — remove the optimistic entry
+						client.remove(entry.queryKey);
+					}
+				}
+			}
+		},
+		onSuccess: (_data, _variables) => {
+			if (invalidateKeys) {
+				for (const key of invalidateKeys) {
+					void client.invalidate(key);
+				}
 			}
 		},
 	});

--- a/packages/query/src/hooks/useOptimisticMutation.test.ts
+++ b/packages/query/src/hooks/useOptimisticMutation.test.ts
@@ -1,0 +1,275 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createQueryClient } from '../client/client.js';
+import { useOptimisticMutation } from './useMutation.js';
+
+describe('useOptimisticMutation', () => {
+	describe('single query', () => {
+		it('should apply optimistic update and rollback on error', async () => {
+			const client = createQueryClient();
+			client.set(['posts'], {
+				data: [{ id: 1, title: 'hello' }],
+				status: 'success',
+				dataUpdatedAt: Date.now(),
+				fetchCount: 1,
+			});
+
+			const result = useOptimisticMutation({
+				mutationFn: () => Promise.reject(new Error('fail')),
+				queries: [
+					{
+						queryKey: ['posts'],
+						optimisticUpdate: (_vars, current) => [
+							...(current ?? []),
+							{ id: 2, title: 'new' },
+						],
+					},
+				],
+				client,
+			});
+
+			expect(client.getQueryData(['posts'])).toEqual([
+				{ id: 1, title: 'hello' },
+			]);
+
+			try {
+				await result.mutateAsync(undefined);
+			} catch {
+				// expected
+			}
+
+			expect(client.getQueryData(['posts'])).toEqual([
+				{ id: 1, title: 'hello' },
+			]);
+		});
+
+		it('should keep optimistic data on success', async () => {
+			const client = createQueryClient();
+			client.set(['posts'], {
+				data: [{ id: 1 }],
+				status: 'success',
+				dataUpdatedAt: Date.now(),
+				fetchCount: 1,
+			});
+
+			const result = useOptimisticMutation({
+				mutationFn: () => Promise.resolve({ id: 2, title: 'created' }),
+				queries: [
+					{
+						queryKey: ['posts'],
+						optimisticUpdate: (_vars, current) => [
+							...(current ?? []),
+							{ id: 2, title: 'created' },
+						],
+					},
+				],
+				client,
+			});
+
+			await result.mutateAsync(undefined);
+
+			expect(client.getQueryData(['posts'])).toEqual([
+				{ id: 1 },
+				{ id: 2, title: 'created' },
+			]);
+		});
+	});
+
+	describe('multiple queries', () => {
+		it('should update multiple queries optimistically', async () => {
+			const client = createQueryClient();
+			client.set(['posts'], {
+				data: [{ id: 1 }],
+				status: 'success',
+				dataUpdatedAt: Date.now(),
+				fetchCount: 1,
+			});
+			client.set(['users', 'alice'], {
+				data: { name: 'alice', postCount: 1 },
+				status: 'success',
+				dataUpdatedAt: Date.now(),
+				fetchCount: 1,
+			});
+
+			const result = useOptimisticMutation({
+				mutationFn: () => Promise.resolve({ id: 2, title: 'new' }),
+				queries: [
+					{
+						queryKey: ['posts'],
+						optimisticUpdate: (_vars, current) => [
+							...(current ?? []),
+							{ id: 2, title: 'new' },
+						],
+					},
+					{
+						queryKey: ['users', 'alice'],
+						optimisticUpdate: (_vars, current) => ({
+							...(current ?? { name: 'alice' }),
+							postCount: (current?.postCount ?? 0) + 1,
+						}),
+					},
+				],
+				client,
+			});
+
+			await result.mutateAsync(undefined);
+
+			expect(client.getQueryData(['posts'])).toEqual([
+				{ id: 1 },
+				{ id: 2, title: 'new' },
+			]);
+			expect(client.getQueryData(['users', 'alice'])).toEqual({
+				name: 'alice',
+				postCount: 2,
+			});
+		});
+
+		it('should rollback ALL queries on error', async () => {
+			const client = createQueryClient();
+			client.set(['posts'], {
+				data: [{ id: 1 }],
+				status: 'success',
+				dataUpdatedAt: Date.now(),
+				fetchCount: 1,
+			});
+			client.set(['users', 'alice'], {
+				data: { name: 'alice', postCount: 1 },
+				status: 'success',
+				dataUpdatedAt: Date.now(),
+				fetchCount: 1,
+			});
+
+			const result = useOptimisticMutation({
+				mutationFn: () => Promise.reject(new Error('fail')),
+				queries: [
+					{
+						queryKey: ['posts'],
+						optimisticUpdate: (_vars, current) => [
+							...(current ?? []),
+							{ id: 2 },
+						],
+					},
+					{
+						queryKey: ['users', 'alice'],
+						optimisticUpdate: (_vars, current) => ({
+							...(current ?? {}),
+							postCount: (current?.postCount ?? 0) + 1,
+						}),
+					},
+				],
+				client,
+			});
+
+			try {
+				await result.mutateAsync(undefined);
+			} catch {
+				// expected
+			}
+
+			expect(client.getQueryData(['posts'])).toEqual([{ id: 1 }]);
+			expect(client.getQueryData(['users', 'alice'])).toEqual({
+				name: 'alice',
+				postCount: 1,
+			});
+		});
+
+		it('should invalidate keys on success', async () => {
+			const client = createQueryClient();
+			client.set(['posts'], {
+				data: [{ id: 1 }],
+				status: 'success',
+				dataUpdatedAt: Date.now(),
+				fetchCount: 1,
+			});
+			client.set(['posts', 'recent'], {
+				data: [{ id: 1 }],
+				status: 'success',
+				dataUpdatedAt: Date.now(),
+				fetchCount: 1,
+			});
+
+			const invalidateSpy = vi.spyOn(client, 'invalidate');
+
+			const result = useOptimisticMutation({
+				mutationFn: () => Promise.resolve({ id: 2 }),
+				queries: [
+					{
+						queryKey: ['posts'],
+						optimisticUpdate: (_vars, current) => [
+							...(current ?? []),
+							{ id: 2 },
+						],
+					},
+				],
+				invalidateKeys: [['posts', 'recent']],
+				client,
+			});
+
+			await result.mutateAsync(undefined);
+
+			expect(invalidateSpy).toHaveBeenCalledWith(['posts', 'recent']);
+			invalidateSpy.mockRestore();
+		});
+
+		it('should remove optimistic entry on rollback if no prior snapshot', async () => {
+			const client = createQueryClient();
+			// No prior data for 'comments'
+
+			const result = useOptimisticMutation({
+				mutationFn: () => Promise.reject(new Error('fail')),
+				queries: [
+					{
+						queryKey: ['comments'],
+						optimisticUpdate: (_vars, _current) => [{ id: 1 }],
+					},
+				],
+				client,
+			});
+
+			try {
+				await result.mutateAsync(undefined);
+			} catch {
+				// expected
+			}
+
+			expect(client.getQueryData(['comments'])).toBeUndefined();
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should handle empty queries array', async () => {
+			const client = createQueryClient();
+
+			const result = useOptimisticMutation({
+				mutationFn: () => Promise.resolve('ok'),
+				queries: [],
+				client,
+			});
+
+			await expect(result.mutateAsync(undefined)).resolves.toBe('ok');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Closes #160

Redesigns `useOptimisticMutation` to support multiple query keys with per-key optimistic updaters and selective invalidation after success.

## API

```ts
useOptimisticMutation({
  mutationFn: createPost,
  queries: [
    {
      queryKey: ['posts'],
      optimisticUpdate: (newPost, posts) => [...posts, newPost],
    },
    {
      queryKey: ['users', userId],
      optimisticUpdate: (newPost, user) => ({
        ...user,
        postCount: user.postCount + 1,
      }),
    },
  ],
  invalidateKeys: [['posts', 'recent']],
});
```

## Changes

- `useOptimisticMutation` now requires `queries: OptimisticQueryConfig[]`
- `OptimisticQueryConfig` carries `queryKey` + `optimisticUpdate` per query
- `invalidateKeys` optionally invalidates other queries on success
- Rollback restores all queries on error; removes entry if no prior snapshot existed
- Removed unused `useQueryClient()` call from `useMutation`
- Exported `OptimisticQueryConfig` type

## Verification

- [x] 198 tests passing (15 test files)
- [x] 7 new optimistic mutation tests
- [x] Single query, multi-key, rollback, invalidation, no-snapshot removal all tested