### PR TITLE
feat(query): MutationCache architecture, Mutation state machine, and useIsMutating hook (#164)

### DIFF
--- a/packages/query/src/client/client.ts
+++ b/packages/query/src/client/client.ts
@@ -44,7 +44,7 @@ import {
 	type QueryCacheInternals,
 	type QueryHandlerDeps,
 } from '../handlers/index.js';
-import { QueryCache, Query } from '../core/index.js';
+import { QueryCache, Query, MutationCache } from '../core/index.js';
 import type { QueryConfig } from '../core/types.js';
 import type { DehydratedState, DehydrateOptions } from '../core/hydration.js';
 
@@ -106,6 +106,8 @@ export interface QueryClientApi {
 	) => Query<TData, TError>;
 	/** The underlying QueryCache instance. */
 	readonly queryCache: QueryCache;
+	/** The underlying MutationCache instance. */
+	readonly mutationCache: MutationCache;
 	/** Serialize cache state to a dehydrated object for SSR. */
 	readonly dehydrate: (options?: DehydrateOptions) => DehydratedState;
 	/** Restore cache state from a dehydrated object. */
@@ -133,6 +135,7 @@ const createQueryClientImpl = (): QueryClientApi => {
 	};
 
 	const queryCache = new QueryCache();
+	const mutationCache = new MutationCache();
 
 	return {
 		get: <T>(key: QueryKey): CacheEntry<T> | undefined => {
@@ -345,6 +348,7 @@ const createQueryClientImpl = (): QueryClientApi => {
 		},
 
 		queryCache,
+		mutationCache,
 
 		dehydrate: (options?: DehydrateOptions): DehydratedState => {
 			return queryCache.dehydrate(options);

--- a/packages/query/src/core/mutation-cache.test.ts
+++ b/packages/query/src/core/mutation-cache.test.ts
@@ -1,0 +1,142 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { MutationCache } from './mutation-cache.js';
+import { Mutation } from './mutation.js';
+
+describe('MutationCache', () => {
+	it('builds and retrieves mutations', () => {
+		const cache = new MutationCache();
+		const mutation = cache.build({
+			mutationKey: ['create-user'],
+			mutationFn: async () => 'ok',
+		});
+
+		expect(mutation).toBeInstanceOf(Mutation);
+		expect(cache.get(['create-user'])).toBe(mutation);
+		expect(cache.size).toBe(1);
+	});
+
+	it('returns existing mutation for same key', () => {
+		const cache = new MutationCache();
+		const m1 = cache.build({ mutationKey: ['a'], mutationFn: async () => 'a' });
+		const m2 = cache.build({ mutationKey: ['a'], mutationFn: async () => 'b' });
+
+		expect(m1).toBe(m2);
+	});
+
+	it('removes mutations', () => {
+		const cache = new MutationCache();
+		cache.build({ mutationKey: ['a'], mutationFn: async () => 'a' });
+
+		expect(cache.remove(['a'])).toBe(true);
+		expect(cache.get(['a'])).toBeUndefined();
+		expect(cache.remove(['a'])).toBe(false);
+	});
+
+	it('clears all mutations', () => {
+		const cache = new MutationCache();
+		cache.build({ mutationKey: ['a'], mutationFn: async () => 'a' });
+		cache.build({ mutationKey: ['b'], mutationFn: async () => 'b' });
+
+		cache.clear();
+		expect(cache.size).toBe(0);
+	});
+
+	it('returns all states', () => {
+		const cache = new MutationCache();
+		cache.build({ mutationKey: ['a'], mutationFn: async () => 'a' });
+
+		const states = cache.getAllStates();
+		expect(states).toHaveLength(1);
+		expect(states[0].status).toBe('idle');
+	});
+
+	it('tracks pending count', async () => {
+		const cache = new MutationCache();
+		const mutation = cache.build({
+			mutationKey: ['slow'],
+			mutationFn: async () => {
+				await new Promise((resolve) => setTimeout(resolve, 50));
+				return 'done';
+			},
+		});
+
+		expect(cache.pendingCount).toBe(0);
+
+		mutation.execute('vars');
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(cache.pendingCount).toBe(1);
+
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(cache.pendingCount).toBe(0);
+	});
+
+	it('notifies subscribers on state changes', async () => {
+		const cache = new MutationCache();
+		const callback = vi.fn();
+		cache.subscribe(callback);
+
+		const mutation = cache.build({
+			mutationKey: ['a'],
+			mutationFn: async () => 'ok',
+		});
+
+		await mutation.execute('vars');
+		expect(callback).toHaveBeenCalled();
+	});
+
+	it('unsubscribes correctly', async () => {
+		const cache = new MutationCache();
+		const callback = vi.fn();
+		const unsubscribe = cache.subscribe(callback);
+		unsubscribe();
+
+		const mutation = cache.build({
+			mutationKey: ['a'],
+			mutationFn: async () => 'ok',
+		});
+
+		await mutation.execute('vars');
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it('invokes global listeners', async () => {
+		const onSuccess = vi.fn();
+		const onError = vi.fn();
+		const onSettled = vi.fn();
+
+		const cache = new MutationCache({ onSuccess, onError, onSettled });
+		const mutation = cache.build({
+			mutationKey: ['a'],
+			mutationFn: async () => 'ok',
+		});
+
+		await mutation.execute('vars');
+		expect(onSuccess).toHaveBeenCalledWith('ok', 'vars', undefined);
+		expect(onSettled).toHaveBeenCalledWith('ok', null, 'vars', undefined);
+		expect(onError).not.toHaveBeenCalled();
+	});
+});

--- a/packages/query/src/core/mutation-cache.ts
+++ b/packages/query/src/core/mutation-cache.ts
@@ -1,0 +1,143 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { Mutation } from './mutation.js';
+import type { MutationConfig, MutationState } from './mutation.js';
+
+const hashKey = (key: readonly unknown[]): string => JSON.stringify(key);
+
+/**
+ * Manages Mutation instances by their mutation key.
+ * Creates mutations on demand and notifies subscribers of state changes.
+ */
+export class MutationCache {
+	private mutations: Map<string, Mutation<unknown, Error, unknown, unknown>> = new Map();
+	private subscribers: Set<() => void> = new Set();
+	private globalListeners?: {
+		onSuccess?: (data: unknown, variables: unknown, context: unknown | undefined) => void;
+		onError?: (error: Error, variables: unknown, context: unknown | undefined) => void;
+		onSettled?: (data: unknown | undefined, error: Error | null, variables: unknown, context: unknown | undefined) => void;
+	};
+
+	constructor(options?: {
+		onSuccess?: (data: unknown, variables: unknown, context: unknown | undefined) => void;
+		onError?: (error: Error, variables: unknown, context: unknown | undefined) => void;
+		onSettled?: (data: unknown | undefined, error: Error | null, variables: unknown, context: unknown | undefined) => void;
+	}) {
+		this.globalListeners = options;
+	}
+
+	build<TData, TError = Error, TVariables = unknown, TContext = unknown>(
+		config: MutationConfig<TData, TError, TVariables, TContext>
+	): Mutation<TData, TError, TVariables, TContext> {
+		const key = config.mutationKey ?? [];
+		const hash = hashKey(key);
+		const existing = this.mutations.get(hash);
+
+		if (existing) {
+			return existing as Mutation<TData, TError, TVariables, TContext>;
+		}
+
+		const mergedConfig: MutationConfig<TData, TError, TVariables, TContext> = {
+			...config,
+			onSuccess: (data, variables, context) => {
+				config.onSuccess?.(data, variables, context);
+				this.globalListeners?.onSuccess?.(data, variables, context);
+			},
+			onError: (error, variables, context) => {
+				config.onError?.(error, variables, context);
+				this.globalListeners?.onError?.(error, variables, context);
+			},
+			onSettled: (data, error, variables, context) => {
+				config.onSettled?.(data, error, variables, context);
+				this.globalListeners?.onSettled?.(data, error, variables, context);
+			},
+		};
+
+		const mutation = new Mutation<TData, TError, TVariables, TContext>(mergedConfig);
+		this.mutations.set(hash, mutation as Mutation<unknown, Error, unknown, unknown>);
+
+		const originalDispatch = mutation.dispatch.bind(mutation);
+		mutation.dispatch = (action) => {
+			originalDispatch(action);
+			this.notify();
+		};
+
+		return mutation;
+	}
+
+	get<TData, TError = Error, TVariables = unknown, TContext = unknown>(
+		key: readonly unknown[]
+	): Mutation<TData, TError, TVariables, TContext> | undefined {
+		const hash = hashKey(key);
+		return this.mutations.get(hash) as Mutation<TData, TError, TVariables, TContext> | undefined;
+	}
+
+	remove(key: readonly unknown[]): boolean {
+		const hash = hashKey(key);
+		const mutation = this.mutations.get(hash);
+		if (mutation) {
+			mutation.reset();
+			this.mutations.delete(hash);
+			return true;
+		}
+		return false;
+	}
+
+	getAll(): Mutation<unknown, Error, unknown, unknown>[] {
+		return Array.from(this.mutations.values());
+	}
+
+	getAllStates(): MutationState<unknown, Error, unknown>[] {
+		return this.getAll().map((m) => m.currentState);
+	}
+
+	clear(): void {
+		for (const mutation of this.mutations.values()) {
+			mutation.reset();
+		}
+		this.mutations.clear();
+	}
+
+	get size(): number {
+		return this.mutations.size;
+	}
+
+	get pendingCount(): number {
+		return this.getAll().filter((m) => m.isPending).length;
+	}
+
+	subscribe(callback: () => void): () => void {
+		this.subscribers.add(callback);
+		return () => {
+			this.subscribers.delete(callback);
+		};
+	}
+
+	notify(): void {
+		for (const subscriber of this.subscribers) {
+			subscriber();
+		}
+	}
+}

--- a/packages/query/src/core/mutation.test.ts
+++ b/packages/query/src/core/mutation.test.ts
@@ -1,0 +1,180 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { Mutation } from './mutation.js';
+
+describe('Mutation', () => {
+	it('starts in idle state', () => {
+		const mutation = new Mutation({
+			mutationFn: async () => 'ok',
+		});
+
+		expect(mutation.currentState.status).toBe('idle');
+		expect(mutation.currentState.data).toBeUndefined();
+		expect(mutation.currentState.error).toBeNull();
+	});
+
+	it('transitions to pending then success', async () => {
+		const mutation = new Mutation({
+			mutationFn: async () => 'success',
+		});
+
+		const promise = mutation.execute('vars');
+		expect(mutation.currentState.status).toBe('pending');
+
+		const data = await promise;
+		expect(data).toBe('success');
+		expect(mutation.currentState.status).toBe('success');
+		expect(mutation.currentState.data).toBe('success');
+		expect(mutation.currentState.error).toBeNull();
+	});
+
+	it('transitions to error on failure', async () => {
+		const mutation = new Mutation({
+			mutationFn: async () => {
+				throw new Error('fail');
+			},
+		});
+
+		await expect(mutation.execute('vars')).rejects.toThrow('fail');
+		expect(mutation.currentState.status).toBe('error');
+		expect(mutation.currentState.error).toBeInstanceOf(Error);
+		expect(mutation.currentState.failureCount).toBe(1);
+	});
+
+	it('calls lifecycle callbacks in order', async () => {
+		const onMutate = vi.fn(async () => ({ context: true }));
+		const onSuccess = vi.fn();
+		const onSettled = vi.fn();
+
+		const mutation = new Mutation({
+			mutationFn: async () => 'data',
+			onMutate,
+			onSuccess,
+			onSettled,
+		});
+
+		await mutation.execute('vars');
+
+		expect(onMutate).toHaveBeenCalledWith('vars');
+		expect(onSuccess).toHaveBeenCalledWith('data', 'vars', { context: true });
+		expect(onSettled).toHaveBeenCalledWith('data', null, 'vars', { context: true });
+	});
+
+	it('calls onError and onSettled on failure', async () => {
+		const onError = vi.fn();
+		const onSettled = vi.fn();
+
+		const mutation = new Mutation({
+			mutationFn: async () => {
+				throw new Error('boom');
+			},
+			onError,
+			onSettled,
+		});
+
+		await expect(mutation.execute('vars')).rejects.toThrow('boom');
+
+		expect(onError).toHaveBeenCalledWith(expect.any(Error), 'vars', undefined);
+		expect(onSettled).toHaveBeenCalledWith(undefined, expect.any(Error), 'vars', undefined);
+	});
+
+	it('notifies observers on state changes', async () => {
+		const mutation = new Mutation({
+			mutationFn: async () => 'ok',
+		});
+
+		const observer = { onMutationUpdate: vi.fn() };
+		mutation.addObserver(observer);
+
+		await mutation.execute('vars');
+
+		expect(observer.onMutationUpdate).toHaveBeenCalledTimes(3);
+	});
+
+	it('resets to idle state', async () => {
+		const mutation = new Mutation({
+			mutationFn: async () => 'ok',
+		});
+
+		await mutation.execute('vars');
+		expect(mutation.currentState.status).toBe('success');
+
+		mutation.reset();
+		expect(mutation.currentState.status).toBe('idle');
+		expect(mutation.currentState.data).toBeUndefined();
+	});
+
+	it('retries on failure and eventually succeeds', async () => {
+		let attempts = 0;
+		const mutation = new Mutation({
+			mutationFn: async () => {
+				attempts++;
+				if (attempts < 3) throw new Error('retry');
+				return 'finally';
+			},
+			retry: 2,
+			retryDelay: 10,
+		});
+
+		const data = await mutation.execute('vars');
+		expect(data).toBe('finally');
+		expect(attempts).toBe(3);
+		expect(mutation.currentState.failureCount).toBe(0);
+	});
+
+	it('times out when execution exceeds timeout', async () => {
+		const mutation = new Mutation({
+			mutationFn: async () => {
+				await new Promise((resolve) => setTimeout(resolve, 100));
+				return 'late';
+			},
+			timeout: 10,
+			retry: 0,
+		});
+
+		await expect(mutation.execute('vars')).rejects.toThrow('timed out');
+	});
+
+	it('deduplicates concurrent executions', async () => {
+		let calls = 0;
+		const mutation = new Mutation({
+			mutationFn: async () => {
+				calls++;
+				await new Promise((resolve) => setTimeout(resolve, 20));
+				return 'ok';
+			},
+		});
+
+		const [r1, r2] = await Promise.all([
+			mutation.execute('a'),
+			mutation.execute('b'),
+		]);
+
+		expect(calls).toBe(1);
+		expect(r1).toBe('ok');
+		expect(r2).toBe('ok');
+	});
+});

--- a/packages/query/src/core/mutation.ts
+++ b/packages/query/src/core/mutation.ts
@@ -1,0 +1,272 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import type { RetryConfig } from '../execution/index.js';
+
+export type MutationStatus = 'idle' | 'pending' | 'success' | 'error';
+
+export interface MutationState<TData = unknown, TError = Error, TVariables = unknown> {
+	readonly data: TData | undefined;
+	readonly error: TError | null;
+	readonly variables: TVariables | undefined;
+	readonly status: MutationStatus;
+	readonly submittedAt: number;
+	readonly failureCount: number;
+	readonly failureReason: TError | null;
+}
+
+export type MutationAction<TData = unknown, TError = Error, TVariables = unknown> =
+	| { readonly type: 'run'; readonly variables: TVariables }
+	| { readonly type: 'success'; readonly data: TData }
+	| { readonly type: 'error'; readonly error: TError }
+	| { readonly type: 'reset' };
+
+export interface MutationConfig<TData = unknown, TError = Error, TVariables = unknown, TContext = unknown> {
+	readonly mutationFn: (variables: TVariables) => Promise<TData>;
+	readonly mutationKey?: readonly unknown[];
+	readonly retry?: RetryConfig | number | boolean;
+	readonly retryDelay?: number;
+	readonly timeout?: number;
+	readonly onMutate?: (variables: TVariables) => TContext | Promise<TContext>;
+	readonly onSuccess?: (data: TData, variables: TVariables, context: TContext | undefined) => void;
+	readonly onError?: (error: TError, variables: TVariables, context: TContext | undefined) => void;
+	readonly onSettled?: (data: TData | undefined, error: TError | null, variables: TVariables, context: TContext | undefined) => void;
+}
+
+export interface MutationObserver<TData = unknown, TError = Error, TVariables = unknown> {
+	readonly onMutationUpdate: () => void;
+}
+
+let mutationIdCounter = 0;
+
+const createInitialState = <TData, TError, TVariables>(): MutationState<TData, TError, TVariables> => ({
+	data: undefined,
+	error: null,
+	variables: undefined,
+	status: 'idle',
+	submittedAt: 0,
+	failureCount: 0,
+	failureReason: null,
+});
+
+const mutationReducer = <TData, TError, TVariables>(
+	state: MutationState<TData, TError, TVariables>,
+	action: MutationAction<TData, TError, TVariables>
+): MutationState<TData, TError, TVariables> => {
+	switch (action.type) {
+		case 'run':
+			return {
+				...state,
+				variables: action.variables,
+				status: 'pending',
+				submittedAt: Date.now(),
+			};
+		case 'success':
+			return {
+				...state,
+				data: action.data,
+				error: null,
+				status: 'success',
+				failureCount: 0,
+				failureReason: null,
+			};
+		case 'error':
+			return {
+				...state,
+				error: action.error,
+				status: 'error',
+				failureCount: state.failureCount + 1,
+				failureReason: action.error,
+			};
+		case 'reset':
+			return createInitialState<TData, TError, TVariables>();
+		default:
+			return state;
+	}
+};
+
+const sleep = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Represents a single mutation.
+ * Manages its own state machine and lifecycle.
+ */
+export class Mutation<TData = unknown, TError = Error, TVariables = unknown, TContext = unknown> {
+	readonly mutationId: number;
+	readonly options: MutationConfig<TData, TError, TVariables, TContext>;
+
+	private state: MutationState<TData, TError, TVariables>;
+	private observers: Set<MutationObserver<TData, TError, TVariables>> = new Set();
+	private abortController: AbortController | null = null;
+	private promise: Promise<TData> | null = null;
+
+	constructor(options: MutationConfig<TData, TError, TVariables, TContext>) {
+		this.options = options;
+		this.state = createInitialState<TData, TError, TVariables>();
+		this.mutationId = ++mutationIdCounter;
+	}
+
+	get currentState(): MutationState<TData, TError, TVariables> {
+		return this.state;
+	}
+
+	get isPending(): boolean {
+		return this.state.status === 'pending';
+	}
+
+	addObserver(observer: MutationObserver<TData, TError, TVariables>): () => void {
+		this.observers.add(observer);
+		return () => {
+			this.observers.delete(observer);
+		};
+	}
+
+	dispatch(action: MutationAction<TData, TError, TVariables>): void {
+		const prevState = this.state;
+		this.state = mutationReducer(prevState, action);
+		if (prevState !== this.state) {
+			this.notifyObservers();
+		}
+	}
+
+	reset(): void {
+		if (this.abortController) {
+			this.abortController.abort();
+			this.abortController = null;
+		}
+		this.promise = null;
+		this.dispatch({ type: 'reset' });
+	}
+
+	async execute(variables: TVariables): Promise<TData> {
+		if (this.promise) {
+			return this.promise;
+		}
+
+		this.reset();
+		this.dispatch({ type: 'run', variables });
+
+		const { mutationFn, timeout, onMutate, onSuccess, onError, onSettled } = this.options;
+
+		let context: TContext | undefined;
+		if (onMutate) {
+			try {
+				const result = onMutate(variables);
+				context = result instanceof Promise ? await result : result;
+			} catch (mutateError) {
+				const error = mutateError instanceof Error ? mutateError : new Error(String(mutateError)) as TError;
+				this.dispatch({ type: 'error', error });
+				if (onError) onError(error, variables, context);
+				if (onSettled) onSettled(undefined, error, variables, context);
+				throw error;
+			}
+		}
+
+		this.promise = this.runWithRetry(mutationFn, variables, timeout, context);
+
+		try {
+			const data = await this.promise;
+			this.dispatch({ type: 'success', data });
+			if (onSuccess) onSuccess(data, variables, context);
+			if (onSettled) onSettled(data, null, variables, context);
+			return data;
+		} catch (error) {
+			const err = error instanceof Error ? error : new Error(String(error));
+			this.dispatch({ type: 'error', error: err as TError });
+			if (onError) onError(err as TError, variables, context);
+			if (onSettled) onSettled(undefined, err as TError, variables, context);
+			throw err;
+		} finally {
+			this.promise = null;
+			this.abortController = null;
+		}
+	}
+
+	private async runWithRetry(
+		mutationFn: (variables: TVariables) => Promise<TData>,
+		variables: TVariables,
+		timeout: number | undefined,
+		_context: TContext | undefined
+	): Promise<TData> {
+		const { retry = 0, retryDelay = 1000 } = this.options;
+		const maxRetries =
+			typeof retry === 'number'
+				? retry
+				: retry === true
+					? 3
+					: retry === false
+						? 0
+						: retry.times ?? 0;
+
+		let lastError: Error | undefined;
+		this.abortController = new AbortController();
+		const signal = this.abortController.signal;
+
+		for (let attempt = 0; attempt <= maxRetries; attempt++) {
+			if (signal.aborted) {
+				throw new Error('Mutation was cancelled');
+			}
+
+			try {
+				const promise = mutationFn(variables);
+
+				if (timeout && timeout > 0) {
+					const timeoutPromise = new Promise<never>((_, reject) => {
+						const timer = setTimeout(() => {
+							reject(new Error(`Mutation timed out after ${timeout}ms`));
+						}, timeout);
+						signal.addEventListener('abort', () => {
+							clearTimeout(timer);
+							reject(new Error('Mutation was cancelled'));
+						});
+					});
+
+					return await Promise.race([promise, timeoutPromise]);
+				}
+
+				return await promise;
+			} catch (error) {
+				if (signal.aborted) {
+					throw new Error('Mutation was cancelled');
+				}
+
+				lastError = error instanceof Error ? error : new Error(String(error));
+
+				if (attempt < maxRetries) {
+					const delay = typeof retryDelay === 'number' ? retryDelay * Math.pow(2, attempt) : 1000 * Math.pow(2, attempt);
+					await sleep(delay);
+				}
+			}
+		}
+
+		throw lastError;
+	}
+
+	private notifyObservers(): void {
+		for (const observer of this.observers) {
+			observer.onMutationUpdate();
+		}
+	}
+}

--- a/packages/query/src/hooks/index.ts
+++ b/packages/query/src/hooks/index.ts
@@ -59,3 +59,4 @@ export {
 export type { PrefetchOptions } from './usePrefetch.js';
 
 export { useIsFetching } from './useIsFetching.js';
+export { useIsMutating } from './useIsMutating.js';

--- a/packages/query/src/hooks/useIsMutating.test.ts
+++ b/packages/query/src/hooks/useIsMutating.test.ts
@@ -1,0 +1,90 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createQueryClient } from '../client/client.js';
+import { useIsMutating } from './useIsMutating.js';
+
+describe('useIsMutating', () => {
+	it('returns 0 when no mutations are pending', () => {
+		const client = createQueryClient();
+		const isMutating = useIsMutating({ client });
+
+		expect(isMutating.value).toBe(0);
+	});
+
+	it('returns the count of pending mutations', async () => {
+		const client = createQueryClient();
+
+		const mutation = client.mutationCache.build({
+			mutationKey: ['test'],
+			mutationFn: async () => {
+				await new Promise((resolve) => setTimeout(resolve, 50));
+				return 'data';
+			},
+		});
+
+		const isMutating = useIsMutating({ client });
+		expect(isMutating.value).toBe(0);
+
+		mutation.execute('vars');
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(isMutating.value).toBe(1);
+
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(isMutating.value).toBe(0);
+	});
+
+	it('tracks multiple concurrent mutations', async () => {
+		const client = createQueryClient();
+
+		const m1 = client.mutationCache.build({
+			mutationKey: ['a'],
+			mutationFn: async () => {
+				await new Promise((resolve) => setTimeout(resolve, 100));
+				return 'a';
+			},
+		});
+
+		const m2 = client.mutationCache.build({
+			mutationKey: ['b'],
+			mutationFn: async () => {
+				await new Promise((resolve) => setTimeout(resolve, 100));
+				return 'b';
+			},
+		});
+
+		const isMutating = useIsMutating({ client });
+		expect(isMutating.value).toBe(0);
+
+		m1.execute('x');
+		m2.execute('y');
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(isMutating.value).toBe(2);
+
+		await new Promise((resolve) => setTimeout(resolve, 150));
+		expect(isMutating.value).toBe(0);
+	});
+});

--- a/packages/query/src/hooks/useIsMutating.ts
+++ b/packages/query/src/hooks/useIsMutating.ts
@@ -22,30 +22,29 @@
  * SOFTWARE.
  */
 
-export { Query } from './query.js';
-export { QueryObserver } from './query-observer.js';
-export { QueryCache } from './query-cache.js';
-export { Mutation } from './mutation.js';
-export { MutationCache } from './mutation-cache.js';
-export { dehydrate, hydrate } from './hydration.js';
+import { signal, computed, type ReadonlySignal } from '@effuse/core';
+import { useQueryClient, type QueryClientApi } from '../client/index.js';
 
-export type {
-	QueryKey,
-	QueryStatus,
-	FetchStatus,
-	QueryFunction,
-	QueryState,
-	QueryAction,
-	QueryConfig,
-	QueryObserverOptions,
-	QueryObserverResult,
-	QueryObserverListener,
-	QuerySnapshot,
-} from './types.js';
+export interface UseIsMutatingOptions {
+	readonly client?: QueryClientApi;
+}
 
-export type {
-	DehydratedState,
-	DehydratedQuery,
-	DehydrateOptions,
-	TypeSerializer,
-} from './hydration.js';
+/**
+ * Returns a reactive signal with the count of currently pending mutations.
+ * Useful for global mutation loading indicators.
+ */
+export const useIsMutating = (options?: UseIsMutatingOptions): ReadonlySignal<number> => {
+	const client = options?.client ?? useQueryClient();
+	const countSignal = signal<number>(0);
+
+	const updateCount = (): void => {
+		countSignal.value = client.mutationCache.pendingCount;
+	};
+
+	updateCount();
+
+	const unsubscribe = client.mutationCache.subscribe(updateCount);
+
+	const result = computed(() => countSignal.value);
+	return result;
+};

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -77,6 +77,7 @@ export {
 	ensureQueryData,
 	usePrefetch,
 	useIsFetching,
+	useIsMutating,
 } from './hooks/index.js';
 
 export type {


### PR DESCRIPTION
## Summary

- `Mutation` class: state machine for a single mutation (`idle` → `pending` → `success` | `error`)
- `MutationCache`: centralized cache for mutations with `subscribe()` / `notify()`, global lifecycle hooks, and deduplication by `mutationKey`
- `useIsMutating`: reactive hook returning the count of pending mutations, symmetric to `useIsFetching`
- `QueryClientApi` now exposes `mutationCache`

## Details

### Mutation
- `execute(variables)` with Promise-based execution
- Built-in retry with exponential backoff
- Timeout support via `Promise.race`
- Deduplicates concurrent executions
- `onMutate`, `onSuccess`, `onError`, `onSettled` callbacks
- Observer pattern for reactive updates

### MutationCache
- `build(config)` creates or returns existing mutation by key
- `subscribe(callback)` / `notify()` for reactive consumers
- Global `onSuccess`, `onError`, `onSettled` listeners
- `pendingCount` for quick access to active mutation count
- `clear()`, `remove(key)`, `getAll()`, `getAllStates()`

### useIsMutating
- Returns `ReadonlySignal<number>`
- Accepts optional `{ client?: QueryClientApi }`
- Subscribes to `MutationCache` changes automatically

## Tests

- `mutation.test.ts` — 10 tests: state transitions, callbacks, observers, reset, retry, timeout, deduplication
- `mutation-cache.test.ts` — 8 tests: build, retrieval, removal, pending count, subscribers, global listeners
- `useIsMutating.test.ts` — 3 tests: zero count, single mutation, multiple concurrent
- Full suite: **227 tests passing** (up from 205)