### PR TITLE
feat(query): improve useInfiniteQuery and add comprehensive jsonplaceholder integration test

### DIFF
--- a/packages/query/src/client/client.ts
+++ b/packages/query/src/client/client.ts
@@ -102,7 +102,7 @@ export interface QueryClientApi {
 	readonly removeQueries: (filters: QueryFilters | QueryKey) => void;
 	/** Get or create a Query from the new QueryCache. */
 	readonly getQuery: <TData, TError = Error>(
-		config: QueryConfig<TData, TError>
+		config: QueryConfig<TData>
 	) => Query<TData, TError>;
 	/** The underlying QueryCache instance. */
 	readonly queryCache: QueryCache;
@@ -320,7 +320,7 @@ const createQueryClientImpl = (): QueryClientApi => {
 		},
 
 		getQuery: <TData, TError = Error>(
-			config: QueryConfig<TData, TError>
+			config: QueryConfig<TData>
 		): Query<TData, TError> => {
 			const query = queryCache.getOrCreate(config);
 
@@ -339,12 +339,12 @@ const createQueryClientImpl = (): QueryClientApi => {
 					fetchCount: existing.fetchCount ?? 0,
 					isInvalidated: existing.isInvalidated ?? false,
 					...(existing.error
-						? { error: existing.error as TError, errorUpdatedAt: existing.errorUpdatedAt ?? Date.now() }
+						? { error: existing.error as unknown as Error, errorUpdatedAt: existing.errorUpdatedAt ?? Date.now() }
 						: {}),
 				});
 			}
 
-			return query;
+			return query as Query<TData, TError>;
 		},
 
 		queryCache,

--- a/packages/query/src/core/hydration.ts
+++ b/packages/query/src/core/hydration.ts
@@ -60,7 +60,9 @@ const BUILTIN_SERIALIZERS: TypeSerializer<unknown>[] = [
 		deserialize: (value) => {
 			const obj = value as { message: string; stack?: string; name?: string };
 			const err = new Error(obj.message);
-			err.stack = obj.stack;
+			if (obj.stack !== undefined) {
+				err.stack = obj.stack;
+			}
 			err.name = obj.name ?? 'Error';
 			return err;
 		},

--- a/packages/query/src/core/jsonplaceholder-integration.test.ts
+++ b/packages/query/src/core/jsonplaceholder-integration.test.ts
@@ -1,0 +1,535 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createQueryClient } from '../client/client.js';
+import { useQuery } from '../hooks/useQuery.js';
+import { useMutation, useOptimisticMutation } from '../hooks/useMutation.js';
+import { useInfiniteQuery } from '../hooks/useInfiniteQuery.js';
+import { useIsFetching } from '../hooks/useIsFetching.js';
+import { useIsMutating } from '../hooks/useIsMutating.js';
+import { createQueryKeys } from '../utils/createQueryKeys.js';
+import { prefetchQuery, fetchQuery } from '../hooks/usePrefetch.js';
+
+const API_BASE = 'https://jsonplaceholder.typicode.com';
+
+const fetchJson = async <T>(url: string): Promise<T> => {
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+	}
+	return response.json() as Promise<T>;
+};
+
+interface Post {
+	readonly userId: number;
+	readonly id: number;
+	readonly title: string;
+	readonly body: string;
+}
+
+interface User {
+	readonly id: number;
+	readonly name: string;
+	readonly email: string;
+}
+
+interface Comment {
+	readonly postId: number;
+	readonly id: number;
+	readonly name: string;
+	readonly email: string;
+	readonly body: string;
+}
+
+interface CreatePostInput {
+	readonly title: string;
+	readonly body: string;
+	readonly userId: number;
+}
+
+describe('jsonplaceholder.typicode.com integration', () => {
+	describe('useQuery', () => {
+		it('fetches a list of posts', async () => {
+			const client = createQueryClient();
+			const result = useQuery({
+				queryKey: ['posts'],
+				queryFn: () => fetchJson<Post[]>(`${API_BASE}/posts?_limit=5`),
+				client,
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			expect(result.status.value).toBe('success');
+			expect(result.data.value).toBeDefined();
+			expect(Array.isArray(result.data.value)).toBe(true);
+			expect(result.data.value!.length).toBe(5);
+			expect(result.data.value![0]).toHaveProperty('id');
+			expect(result.data.value![0]).toHaveProperty('title');
+			expect(result.dataUpdatedAt.value).toBeGreaterThan(0);
+		});
+
+		it('fetches a single user by id', async () => {
+			const client = createQueryClient();
+			const result = useQuery({
+				queryKey: ['users', 1],
+				queryFn: () => fetchJson<User>(`${API_BASE}/users/1`),
+				client,
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			expect(result.status.value).toBe('success');
+			expect(result.data.value).toBeDefined();
+			expect(result.data.value!.id).toBe(1);
+			expect(result.data.value!.name).toBeDefined();
+			expect(result.data.value!.email).toBeDefined();
+		});
+
+		it('fetches comments for a post', async () => {
+			const client = createQueryClient();
+			const result = useQuery({
+				queryKey: ['posts', 1, 'comments'],
+				queryFn: () => fetchJson<Comment[]>(`${API_BASE}/posts/1/comments?_limit=3`),
+				client,
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			expect(result.status.value).toBe('success');
+			expect(Array.isArray(result.data.value)).toBe(true);
+			expect(result.data.value!.length).toBe(3);
+			expect(result.data.value![0]).toHaveProperty('postId');
+		});
+
+		it('caches and shares query data', async () => {
+			const client = createQueryClient();
+
+			const result1 = useQuery({
+				queryKey: ['posts', 'shared'],
+				queryFn: () => fetchJson<Post[]>(`${API_BASE}/posts?_limit=3`),
+				client,
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			const result2 = useQuery({
+				queryKey: ['posts', 'shared'],
+				queryFn: () => fetchJson<Post[]>(`${API_BASE}/posts?_limit=3`),
+				client,
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			expect(result1.data.value).toEqual(result2.data.value);
+			expect(result2.status.value).toBe('success');
+		});
+
+		it('handles errors gracefully', async () => {
+			const client = createQueryClient();
+			const result = useQuery({
+				queryKey: ['error-test'],
+				queryFn: () => fetchJson<unknown>(`${API_BASE}/nonexistent-endpoint-12345`),
+				retry: 0,
+				timeout: 2000,
+				client,
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 1000));
+
+			expect(result.status.value).toBe('error');
+			expect(result.error.value).toBeDefined();
+			expect(result.failureCount.value).toBeGreaterThan(0);
+		});
+	});
+
+	describe('useMutation', () => {
+		it('creates a post successfully', async () => {
+			const client = createQueryClient();
+			const result = useMutation<Post, CreatePostInput>({
+				mutationFn: async (input) => {
+					const response = await fetch(`${API_BASE}/posts`, {
+						method: 'POST',
+						body: JSON.stringify(input),
+						headers: { 'Content-Type': 'application/json' },
+					});
+					return response.json() as Promise<Post>;
+				},
+				client,
+			});
+
+			const input: CreatePostInput = {
+				title: 'Test Post',
+				body: 'This is a test post body',
+				userId: 1,
+			};
+
+			await result.mutateAsync(input);
+
+			expect(result.status.value).toBe('success');
+			expect(result.data.value).toBeDefined();
+			expect(result.data.value!.title).toBe(input.title);
+			expect(result.data.value!.body).toBe(input.body);
+			expect(result.data.value!.userId).toBe(input.userId);
+		});
+
+		it('tracks mutation state during execution', async () => {
+			const client = createQueryClient();
+			const result = useMutation<Post, CreatePostInput>({
+				mutationFn: async (input) => {
+					await new Promise((resolve) => setTimeout(resolve, 100));
+					const response = await fetch(`${API_BASE}/posts`, {
+						method: 'POST',
+						body: JSON.stringify(input),
+						headers: { 'Content-Type': 'application/json' },
+					});
+					return response.json() as Promise<Post>;
+				},
+				client,
+			});
+
+			const mutatePromise = result.mutateAsync({
+				title: 'Delayed Post',
+				body: 'This post has a delay',
+				userId: 1,
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			expect(result.status.value).toBe('pending');
+			expect(result.isPending.value).toBe(true);
+
+			await mutatePromise;
+			expect(result.status.value).toBe('success');
+			expect(result.isPending.value).toBe(false);
+		});
+	});
+
+	describe('useInfiniteQuery', () => {
+		it('fetches paginated posts', async () => {
+			const client = createQueryClient();
+			const result = useInfiniteQuery({
+				queryKey: ['posts', 'infinite'],
+				queryFn: async ({ pageParam }) => {
+					return fetchJson<Post[]>(
+						`${API_BASE}/posts?_page=${pageParam}&_limit=3`
+					);
+				},
+				initialPageParam: 1,
+				getNextPageParam: (_lastPage, allPages) =>
+					allPages.length < 3 ? allPages.length + 1 : undefined,
+				client,
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			expect(result.status.value).toBe('success');
+			expect(result.data.value).toBeDefined();
+			expect(result.data.value!.pages).toHaveLength(1);
+			expect(result.data.value!.pages[0]).toHaveLength(3);
+
+			await result.fetchNextPage();
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			expect(result.data.value!.pages).toHaveLength(2);
+			expect(result.isFetchingNextPage.value).toBe(false);
+
+			await result.fetchNextPage();
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			expect(result.data.value!.pages).toHaveLength(3);
+			expect(result.hasNextPage.value).toBe(false);
+		});
+	});
+
+	describe('useIsFetching', () => {
+		it('tracks global fetching state', async () => {
+			const client = createQueryClient();
+			const isFetching = useIsFetching({ client });
+
+			expect(isFetching.value).toBe(0);
+
+			useQuery({
+				queryKey: ['tracking-test'],
+				queryFn: () => fetchJson<Post[]>(`${API_BASE}/posts?_limit=2`),
+				client,
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			expect(isFetching.value).toBeGreaterThanOrEqual(0);
+
+			await new Promise((resolve) => setTimeout(resolve, 500));
+			expect(isFetching.value).toBe(0);
+		});
+	});
+
+	describe('useIsMutating', () => {
+		it('tracks global mutation state', async () => {
+			const client = createQueryClient();
+			const isMutating = useIsMutating({ client });
+
+			expect(isMutating.value).toBe(0);
+
+			const mutation = client.mutationCache.build({
+				mutationKey: ['create-post'],
+				mutationFn: async () => {
+					await new Promise((resolve) => setTimeout(resolve, 100));
+					return { id: 1 };
+				},
+			});
+
+			mutation.execute('vars');
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			expect(isMutating.value).toBe(1);
+
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			expect(isMutating.value).toBe(0);
+		});
+	});
+
+	describe('createQueryKeys', () => {
+		it('generates type-safe keys for jsonplaceholder resources', () => {
+			const postKeys = createQueryKeys('posts', {
+				all: null,
+				byId: (id: number) => [id],
+				comments: (id: number) => [id, 'comments'],
+			});
+
+			expect(postKeys.all()).toEqual(['posts', 'all']);
+			expect(postKeys.byId(1)).toEqual(['posts', 'byId', 1]);
+			expect(postKeys.comments(1)).toEqual(['posts', 'comments', 1, 'comments']);
+
+			const userKeys = createQueryKeys('users', {
+				all: null,
+				byId: (id: number) => [id],
+			});
+
+			expect(userKeys.all()).toEqual(['users', 'all']);
+			expect(userKeys.byId(5)).toEqual(['users', 'byId', 5]);
+		});
+	});
+
+	describe('query cache operations', () => {
+		it('sets and gets query data directly', () => {
+			const client = createQueryClient();
+			const mockPosts: Post[] = [
+				{ userId: 1, id: 1, title: 'Test', body: 'Body' },
+			];
+
+			client.setQueryData(['posts', 'manual'], mockPosts);
+			const data = client.getQueryData<Post[]>(['posts', 'manual']);
+
+			expect(data).toEqual(mockPosts);
+		});
+
+		it('removes queries from cache', () => {
+			const client = createQueryClient();
+			client.setQueryData(['temp'], { value: true });
+			expect(client.getQueryData(['temp'])).toEqual({ value: true });
+
+			client.removeQueries(['temp']);
+			expect(client.getQueryData(['temp'])).toBeUndefined();
+		});
+
+		it('invalidates queries', async () => {
+			const client = createQueryClient();
+			client.set(['invalidate-test'], {
+				data: 'initial',
+				status: 'success',
+				dataUpdatedAt: Date.now(),
+				fetchCount: 1,
+			});
+
+			await client.invalidate(['invalidate-test']);
+			const entry = client.getQueryState(['invalidate-test']);
+			expect(entry?.isInvalidated).toBe(true);
+		});
+	});
+
+	describe('mutation cache operations', () => {
+		it('builds and tracks mutations in cache', async () => {
+			const client = createQueryClient();
+			const mutation = client.mutationCache.build({
+				mutationKey: ['update-post'],
+				mutationFn: async (vars: { id: number; title: string }) => {
+					return vars;
+				},
+			});
+
+			expect(client.mutationCache.size).toBe(1);
+
+			const result = await mutation.execute({ id: 1, title: 'Updated' });
+			expect(result.title).toBe('Updated');
+			expect(mutation.currentState.status).toBe('success');
+		});
+
+		it('shares mutation instances by key', () => {
+			const client = createQueryClient();
+			const m1 = client.mutationCache.build({
+				mutationKey: ['shared'],
+				mutationFn: async () => 'a',
+			});
+			const m2 = client.mutationCache.build({
+				mutationKey: ['shared'],
+				mutationFn: async () => 'b',
+			});
+
+			expect(m1).toBe(m2);
+		});
+	});
+
+	describe('prefetching', () => {
+		it('prefetches data into cache', async () => {
+			const client = createQueryClient();
+
+			await prefetchQuery(
+				['prefetched-posts'],
+				() => fetchJson<Post[]>(`${API_BASE}/posts?_limit=2`),
+				{ client }
+			);
+
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			const cached = client.get<Post[]>(['prefetched-posts']);
+			expect(cached).toBeDefined();
+			expect(Array.isArray(cached?.data)).toBe(true);
+			expect(cached!.data!.length).toBe(2);
+		});
+
+		it('fetchQuery returns data directly', async () => {
+			const client = createQueryClient();
+
+			const data = await fetchQuery(
+				['fetched-posts'],
+				() => fetchJson<Post[]>(`${API_BASE}/posts?_limit=2`),
+				{ client }
+			);
+
+			expect(data).toBeDefined();
+			expect(Array.isArray(data)).toBe(true);
+			expect(data.length).toBe(2);
+		});
+	});
+
+	describe('dehydration and hydration', () => {
+		it('round-trips cache state through dehydrate and hydrate', () => {
+			const client = createQueryClient();
+			const mockPosts: Post[] = [
+				{ userId: 1, id: 1, title: 'Test', body: 'Body' },
+			];
+
+			const query = client.getQuery({
+				queryKey: ['posts', 'hydrate'],
+				queryFn: async () => mockPosts,
+			});
+			query.setState({
+				data: mockPosts,
+				status: 'success',
+				dataUpdatedAt: Date.now(),
+				fetchCount: 1,
+				isInvalidated: false,
+			});
+
+			const dehydrated = client.dehydrate();
+			expect(dehydrated.queries.length).toBeGreaterThan(0);
+
+			const newClient = createQueryClient();
+			// Create the query first so hydration can update it
+			newClient.getQuery({
+				queryKey: ['posts', 'hydrate'],
+				queryFn: async () => mockPosts,
+			});
+			newClient.hydrate(dehydrated);
+
+			const restoredQuery = newClient.queryCache.get(['posts', 'hydrate'])!;
+			expect(restoredQuery.currentState.data).toEqual(mockPosts);
+		});
+	});
+
+	describe('end-to-end workflow', () => {
+		it('completes a full workflow with queries, mutations, and cache', async () => {
+			const client = createQueryClient();
+			const keys = createQueryKeys('posts', {
+				all: null,
+				byId: (id: number) => [id],
+			});
+
+			// 1. Fetch posts
+			const postsQuery = useQuery({
+				queryKey: keys.all(),
+				queryFn: () => fetchJson<Post[]>(`${API_BASE}/posts?_limit=5`),
+				client,
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 500));
+			expect(postsQuery.status.value).toBe('success');
+			const posts = postsQuery.data.value!;
+
+			// 2. Fetch a specific post
+			const postId = posts[0].id;
+			const postQuery = useQuery({
+				queryKey: keys.byId(postId),
+				queryFn: () => fetchJson<Post>(`${API_BASE}/posts/${postId}`),
+				client,
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 500));
+			expect(postQuery.status.value).toBe('success');
+			expect(postQuery.data.value!.id).toBe(postId);
+
+			// 3. Create a new post via mutation
+			const createMutation = useMutation<Post, CreatePostInput>({
+				mutationFn: async (input) => {
+					const response = await fetch(`${API_BASE}/posts`, {
+						method: 'POST',
+						body: JSON.stringify(input),
+						headers: { 'Content-Type': 'application/json' },
+					});
+					return response.json() as Promise<Post>;
+				},
+				client,
+			});
+
+			const newPost = await createMutation.mutateAsync({
+				title: 'Integration Test Post',
+				body: 'Created during end-to-end test',
+				userId: 1,
+			});
+
+			expect(newPost.title).toBe('Integration Test Post');
+			expect(createMutation.status.value).toBe('success');
+
+			// 4. Query results are available
+			expect(postsQuery.data.value).toBeDefined();
+			expect(postQuery.data.value).toBeDefined();
+
+			// 5. QueryCache contains the queries
+			expect(client.queryCache.get(keys.all())).toBeDefined();
+			expect(client.queryCache.get(keys.byId(postId))).toBeDefined();
+
+			// 6. Dehydrate and verify state is serializable
+			const dehydrated = client.dehydrate();
+			expect(dehydrated.queries.length).toBeGreaterThanOrEqual(2);
+		});
+	});
+});

--- a/packages/query/src/core/mutation-cache.ts
+++ b/packages/query/src/core/mutation-cache.ts
@@ -34,21 +34,21 @@ const hashKey = (key: readonly unknown[]): string => JSON.stringify(key);
 export class MutationCache {
 	private mutations: Map<string, Mutation<unknown, Error, unknown, unknown>> = new Map();
 	private subscribers: Set<() => void> = new Set();
-	private globalListeners?: {
+	private globalListeners: {
 		onSuccess?: (data: unknown, variables: unknown, context: unknown | undefined) => void;
 		onError?: (error: Error, variables: unknown, context: unknown | undefined) => void;
 		onSettled?: (data: unknown | undefined, error: Error | null, variables: unknown, context: unknown | undefined) => void;
-	};
+	} | undefined;
 
 	constructor(options?: {
 		onSuccess?: (data: unknown, variables: unknown, context: unknown | undefined) => void;
 		onError?: (error: Error, variables: unknown, context: unknown | undefined) => void;
 		onSettled?: (data: unknown | undefined, error: Error | null, variables: unknown, context: unknown | undefined) => void;
 	}) {
-		this.globalListeners = options;
+		this.globalListeners = options ?? undefined;
 	}
 
-	build<TData, TError = Error, TVariables = unknown, TContext = unknown>(
+	build<TData, TError extends Error = Error, TVariables = unknown, TContext = unknown>(
 		config: MutationConfig<TData, TError, TVariables, TContext>
 	): Mutation<TData, TError, TVariables, TContext> {
 		const key = config.mutationKey ?? [];
@@ -56,7 +56,7 @@ export class MutationCache {
 		const existing = this.mutations.get(hash);
 
 		if (existing) {
-			return existing as Mutation<TData, TError, TVariables, TContext>;
+			return existing as unknown as Mutation<TData, TError, TVariables, TContext>;
 		}
 
 		const mergedConfig: MutationConfig<TData, TError, TVariables, TContext> = {
@@ -76,7 +76,7 @@ export class MutationCache {
 		};
 
 		const mutation = new Mutation<TData, TError, TVariables, TContext>(mergedConfig);
-		this.mutations.set(hash, mutation as Mutation<unknown, Error, unknown, unknown>);
+		this.mutations.set(hash, mutation as unknown as Mutation<unknown, Error, unknown, unknown>);
 
 		const originalDispatch = mutation.dispatch.bind(mutation);
 		mutation.dispatch = (action) => {
@@ -87,11 +87,11 @@ export class MutationCache {
 		return mutation;
 	}
 
-	get<TData, TError = Error, TVariables = unknown, TContext = unknown>(
+	get<TData, TError extends Error = Error, TVariables = unknown, TContext = unknown>(
 		key: readonly unknown[]
 	): Mutation<TData, TError, TVariables, TContext> | undefined {
 		const hash = hashKey(key);
-		return this.mutations.get(hash) as Mutation<TData, TError, TVariables, TContext> | undefined;
+		return this.mutations.get(hash) as unknown as Mutation<TData, TError, TVariables, TContext> | undefined;
 	}
 
 	remove(key: readonly unknown[]): boolean {

--- a/packages/query/src/core/mutation.ts
+++ b/packages/query/src/core/mutation.ts
@@ -26,7 +26,7 @@ import type { RetryConfig } from '../execution/index.js';
 
 export type MutationStatus = 'idle' | 'pending' | 'success' | 'error';
 
-export interface MutationState<TData = unknown, TError = Error, TVariables = unknown> {
+export interface MutationState<TData = unknown, TError extends Error = Error, TVariables = unknown> {
 	readonly data: TData | undefined;
 	readonly error: TError | null;
 	readonly variables: TVariables | undefined;
@@ -36,13 +36,13 @@ export interface MutationState<TData = unknown, TError = Error, TVariables = unk
 	readonly failureReason: TError | null;
 }
 
-export type MutationAction<TData = unknown, TError = Error, TVariables = unknown> =
+export type MutationAction<TData = unknown, TError extends Error = Error, TVariables = unknown> =
 	| { readonly type: 'run'; readonly variables: TVariables }
 	| { readonly type: 'success'; readonly data: TData }
 	| { readonly type: 'error'; readonly error: TError }
 	| { readonly type: 'reset' };
 
-export interface MutationConfig<TData = unknown, TError = Error, TVariables = unknown, TContext = unknown> {
+export interface MutationConfig<TData = unknown, TError extends Error = Error, TVariables = unknown, TContext = unknown> {
 	readonly mutationFn: (variables: TVariables) => Promise<TData>;
 	readonly mutationKey?: readonly unknown[];
 	readonly retry?: RetryConfig | number | boolean;
@@ -54,13 +54,13 @@ export interface MutationConfig<TData = unknown, TError = Error, TVariables = un
 	readonly onSettled?: (data: TData | undefined, error: TError | null, variables: TVariables, context: TContext | undefined) => void;
 }
 
-export interface MutationObserver<TData = unknown, TError = Error, TVariables = unknown> {
+export interface MutationObserver {
 	readonly onMutationUpdate: () => void;
 }
 
 let mutationIdCounter = 0;
 
-const createInitialState = <TData, TError, TVariables>(): MutationState<TData, TError, TVariables> => ({
+const createInitialState = <TData, TError extends Error, TVariables>(): MutationState<TData, TError, TVariables> => ({
 	data: undefined,
 	error: null,
 	variables: undefined,
@@ -70,7 +70,7 @@ const createInitialState = <TData, TError, TVariables>(): MutationState<TData, T
 	failureReason: null,
 });
 
-const mutationReducer = <TData, TError, TVariables>(
+const mutationReducer = <TData, TError extends Error, TVariables>(
 	state: MutationState<TData, TError, TVariables>,
 	action: MutationAction<TData, TError, TVariables>
 ): MutationState<TData, TError, TVariables> => {
@@ -113,12 +113,12 @@ const sleep = (ms: number): Promise<void> =>
  * Represents a single mutation.
  * Manages its own state machine and lifecycle.
  */
-export class Mutation<TData = unknown, TError = Error, TVariables = unknown, TContext = unknown> {
+export class Mutation<TData = unknown, TError extends Error = Error, TVariables = unknown, TContext = unknown> {
 	readonly mutationId: number;
 	readonly options: MutationConfig<TData, TError, TVariables, TContext>;
 
 	private state: MutationState<TData, TError, TVariables>;
-	private observers: Set<MutationObserver<TData, TError, TVariables>> = new Set();
+	private observers: Set<MutationObserver> = new Set();
 	private abortController: AbortController | null = null;
 	private promise: Promise<TData> | null = null;
 
@@ -136,7 +136,7 @@ export class Mutation<TData = unknown, TError = Error, TVariables = unknown, TCo
 		return this.state.status === 'pending';
 	}
 
-	addObserver(observer: MutationObserver<TData, TError, TVariables>): () => void {
+	addObserver(observer: MutationObserver): () => void {
 		this.observers.add(observer);
 		return () => {
 			this.observers.delete(observer);
@@ -175,13 +175,13 @@ export class Mutation<TData = unknown, TError = Error, TVariables = unknown, TCo
 			try {
 				const result = onMutate(variables);
 				context = result instanceof Promise ? await result : result;
-			} catch (mutateError) {
-				const error = mutateError instanceof Error ? mutateError : new Error(String(mutateError)) as TError;
-				this.dispatch({ type: 'error', error });
-				if (onError) onError(error, variables, context);
-				if (onSettled) onSettled(undefined, error, variables, context);
-				throw error;
-			}
+		} catch (mutateError) {
+			const error = (mutateError instanceof Error ? mutateError : new Error(String(mutateError))) as TError;
+			this.dispatch({ type: 'error', error });
+			if (onError) onError(error, variables, context);
+			if (onSettled) onSettled(undefined, error, variables, context);
+			throw error;
+		}
 		}
 
 		this.promise = this.runWithRetry(mutationFn, variables, timeout, context);

--- a/packages/query/src/core/query-cache.ts
+++ b/packages/query/src/core/query-cache.ts
@@ -40,7 +40,7 @@ export class QueryCache {
 	 * Get or create a query for the given key and config.
 	 */
 	getOrCreate<TData, TError = Error>(
-		config: QueryConfig<TData, TError>
+		config: QueryConfig<TData>
 	): Query<TData, TError> {
 		const hash = hashKey(config.queryKey);
 		const existing = this.queries.get(hash);

--- a/packages/query/src/core/query-observer.ts
+++ b/packages/query/src/core/query-observer.ts
@@ -153,7 +153,6 @@ export class QueryObserver<TData = unknown, TError = Error, TSelected = TData> {
 	private currentResult: QueryObserverResult<TSelected, TError>;
 	private listener: QueryObserverListener<TSelected, TError> | null = null;
 	private unsubscribeQuery: (() => void) | null = null;
-	private previousSelectError: Error | null = null;
 	private memo: MemoState<TData, TSelected> = {
 		lastSourceData: undefined,
 		lastSelectedData: undefined,
@@ -256,12 +255,7 @@ export class QueryObserver<TData = unknown, TError = Error, TSelected = TData> {
 
 		try {
 			this.currentResult = createResult(this.query, this.options, this.memo, prevResult);
-			this.previousSelectError = null;
-		} catch (error) {
-			// If select throws, we treat it as an error state
-			const err =
-				error instanceof Error ? error : new Error(String(error));
-			this.previousSelectError = err;
+		} catch (err) {
 			this.currentResult = {
 				...this.currentResult,
 				data: undefined,

--- a/packages/query/src/core/query.ts
+++ b/packages/query/src/core/query.ts
@@ -115,10 +115,10 @@ const queryReducer = <TData, TError = Error>(
 export class Query<TData = unknown, TError = Error> {
 	readonly queryHash: string;
 	readonly queryKey: QueryKey;
-	options: QueryConfig<TData, TError>;
+	options: QueryConfig<TData>;
 
 	private state: QueryState<TData, TError>;
-	private observers: Set<QueryObserver<TData, TError>> = new Set();
+	private observers: Set<QueryObserver> = new Set();
 	private abortController: AbortController | null = null;
 	private gcTimeout: ReturnType<typeof setTimeout> | null = null;
 	private promise: Promise<unknown> | null = null;
@@ -127,7 +127,7 @@ export class Query<TData = unknown, TError = Error> {
 	private cancelledFetchId = 0;
 	private cache: QueryCache | null = null;
 
-	constructor(options: QueryConfig<TData, TError>, cache?: QueryCache) {
+	constructor(options: QueryConfig<TData>, cache?: QueryCache) {
 		this.queryKey = options.queryKey;
 		this.queryHash = hashKey(options.queryKey);
 		this.options = options;
@@ -177,7 +177,7 @@ export class Query<TData = unknown, TError = Error> {
 	 * Subscribe an observer to this query.
 	 * Returns an unsubscribe function.
 	 */
-	addObserver(observer: QueryObserver<TData, TError>): () => void {
+	addObserver(observer: QueryObserver): () => void {
 		this.observers.add(observer);
 		this.cancelGc();
 		return () => {
@@ -258,8 +258,8 @@ export class Query<TData = unknown, TError = Error> {
 				// Fetch was cancelled, ignore result
 				return data as TData;
 			}
-			this.dispatch({ type: 'success', data });
-			return data;
+			this.dispatch({ type: 'success', data: data as TData });
+			return data as TData;
 		} catch (error) {
 			if (currentFetchId <= this.cancelledFetchId) {
 				// Fetch was cancelled, ignore error

--- a/packages/query/src/core/types.ts
+++ b/packages/query/src/core/types.ts
@@ -57,7 +57,7 @@ export type QueryAction<TData = unknown, TError = Error> =
 	| { readonly type: 'setState'; readonly state: Partial<QueryState<TData, TError>> };
 
 /** Base options for configuring a Query. */
-export interface QueryConfig<TData = unknown, TError = Error> {
+export interface QueryConfig<TData = unknown> {
 	readonly queryKey: QueryKey;
 	readonly queryFn: QueryFunction<TData>;
 	readonly staleTime?: number;
@@ -72,7 +72,7 @@ export interface QueryObserverOptions<
 	TData = unknown,
 	TError = Error,
 	TSelected = TData,
-> extends QueryConfig<TData, TError> {
+> extends QueryConfig<TData> {
 	readonly enabled?: boolean;
 	readonly select?: (data: TData) => TSelected;
 	readonly placeholderData?:
@@ -119,6 +119,6 @@ export interface QuerySnapshot<TData = unknown, TError = Error> {
 }
 
 /** Interface that the Query class expects from observers. */
-export interface QueryObserver<TData = unknown, TError = Error> {
+export interface QueryObserver {
 	readonly onQueryUpdate: () => void;
 }

--- a/packages/query/src/hooks/index.ts
+++ b/packages/query/src/hooks/index.ts
@@ -31,6 +31,7 @@ export type {
 	MutationStatus,
 	MutateOptions,
 	OptimisticMutationOptions,
+	OptimisticMutationHookOptions,
 	OptimisticQueryConfig,
 } from './useMutation.js';
 
@@ -46,7 +47,6 @@ export type {
 	InfiniteQueryOptions,
 	UseInfiniteQueryResult,
 	InfiniteData,
-	InfiniteQueryPage,
 } from './useInfiniteQuery.js';
 
 export {

--- a/packages/query/src/hooks/useInfiniteQuery.test.ts
+++ b/packages/query/src/hooks/useInfiniteQuery.test.ts
@@ -1,0 +1,335 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Chris M. Perez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createQueryClient } from '../client/client.js';
+import { useInfiniteQuery } from './useInfiniteQuery.js';
+
+describe('useInfiniteQuery', () => {
+	it('starts in pending state', () => {
+		const client = createQueryClient();
+		const result = useInfiniteQuery({
+			queryKey: ['items'],
+			queryFn: async () => [{ id: 1 }],
+			initialPageParam: 1,
+			getNextPageParam: () => undefined,
+			enabled: false,
+			client,
+		});
+
+		expect(result.status.value).toBe('pending');
+		expect(result.isPending.value).toBe(true);
+		expect(result.isLoading.value).toBe(false);
+		expect(result.isFetching.value).toBe(false);
+		expect(result.data.value).toBeUndefined();
+	});
+
+	it('fetches initial page and sets success state', async () => {
+		const client = createQueryClient();
+		const result = useInfiniteQuery({
+			queryKey: ['items'],
+			queryFn: async ({ pageParam }) => [{ id: pageParam }],
+			initialPageParam: 1,
+			getNextPageParam: () => undefined,
+			client,
+		});
+
+		expect(result.isFetching.value).toBe(true);
+		expect(result.isLoading.value).toBe(true);
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(result.status.value).toBe('success');
+		expect(result.isSuccess.value).toBe(true);
+		expect(result.data.value?.pages).toEqual([[{ id: 1 }]]);
+		expect(result.dataUpdatedAt.value).toBeDefined();
+	});
+
+	it('fetches next page and appends to data', async () => {
+		const client = createQueryClient();
+		const result = useInfiniteQuery({
+			queryKey: ['items'],
+			queryFn: async ({ pageParam }) => [{ id: pageParam }],
+			initialPageParam: 1,
+			getNextPageParam: (_lastPage, allPages) =>
+				allPages.length < 3 ? allPages.length + 1 : undefined,
+			client,
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(result.data.value?.pages).toHaveLength(1);
+
+		await result.fetchNextPage();
+		expect(result.data.value?.pages).toHaveLength(2);
+
+		await result.fetchNextPage();
+		expect(result.data.value?.pages).toHaveLength(3);
+		expect(result.hasNextPage.value).toBe(false);
+	});
+
+	it('tracks isFetchingNextPage during next page fetch', async () => {
+		const client = createQueryClient();
+		const result = useInfiniteQuery({
+			queryKey: ['items'],
+			queryFn: async ({ pageParam }) => {
+				await new Promise((resolve) => setTimeout(resolve, 20));
+				return [{ id: pageParam }];
+			},
+			initialPageParam: 1,
+			getNextPageParam: (_lastPage, allPages) =>
+				allPages.length < 2 ? allPages.length + 1 : undefined,
+			client,
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 30));
+
+		const nextPromise = result.fetchNextPage();
+		await new Promise((resolve) => setTimeout(resolve, 5));
+		expect(result.isFetchingNextPage.value).toBe(true);
+		expect(result.isFetching.value).toBe(true);
+
+		await nextPromise;
+		expect(result.isFetchingNextPage.value).toBe(false);
+		expect(result.isFetching.value).toBe(false);
+	});
+
+	it('fetches previous page and prepends to data', async () => {
+		const client = createQueryClient();
+		const result = useInfiniteQuery({
+			queryKey: ['items'],
+			queryFn: async ({ pageParam }) => [{ id: pageParam }],
+			initialPageParam: 2,
+			getNextPageParam: () => undefined,
+			getPreviousPageParam: (_firstPage, allPages) =>
+				allPages.length < 2 ? 1 : undefined,
+			client,
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(result.data.value?.pages).toHaveLength(1);
+
+		await result.fetchPreviousPage();
+		expect(result.data.value?.pages).toHaveLength(2);
+		expect(result.data.value?.pages[0]).toEqual([{ id: 1 }]);
+	});
+
+	it('handles errors and tracks failure count', async () => {
+		const client = createQueryClient();
+		const result = useInfiniteQuery({
+			queryKey: ['items'],
+			queryFn: async () => {
+				throw new Error('fail');
+			},
+			initialPageParam: 1,
+			getNextPageParam: () => undefined,
+			retry: 0,
+			client,
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(result.status.value).toBe('error');
+		expect(result.isError.value).toBe(true);
+		expect(result.error.value).toBeInstanceOf(Error);
+		expect(result.failureCount.value).toBe(1);
+		expect(result.failureReason.value).toBeInstanceOf(Error);
+		expect(result.errorUpdatedAt.value).toBeDefined();
+	});
+
+	it('retries and eventually succeeds', async () => {
+		let attempts = 0;
+		const client = createQueryClient();
+		const result = useInfiniteQuery({
+			queryKey: ['items'],
+			queryFn: async () => {
+				attempts++;
+				if (attempts < 3) throw new Error('retry');
+				return [{ id: 1 }];
+			},
+			initialPageParam: 1,
+			getNextPageParam: () => undefined,
+			retry: 2,
+			retryDelay: 10,
+			client,
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		expect(result.status.value).toBe('success');
+		expect(attempts).toBe(3);
+		expect(result.failureCount.value).toBe(0);
+	});
+
+	it('cancels in-flight fetch', async () => {
+		const client = createQueryClient();
+		const result = useInfiniteQuery({
+			queryKey: ['items'],
+			queryFn: async ({ signal }) => {
+				await new Promise((resolve, reject) => {
+					signal.addEventListener('abort', () => reject(new Error('cancelled')));
+					setTimeout(resolve, 100);
+				});
+				return [{ id: 1 }];
+			},
+			initialPageParam: 1,
+			getNextPageParam: () => undefined,
+			client,
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		result.cancel();
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(result.fetchStatus.value).toBe('idle');
+	});
+
+	it('uses initialData when provided', () => {
+		const client = createQueryClient();
+		const initialData = {
+			pages: [[{ id: 1 }]],
+			pageParams: [1],
+		};
+
+		const result = useInfiniteQuery({
+			queryKey: ['items'],
+			queryFn: async () => [{ id: 2 }],
+			initialPageParam: 1,
+			getNextPageParam: () => undefined,
+			initialData,
+			client,
+		});
+
+		expect(result.status.value).toBe('success');
+		expect(result.data.value).toEqual(initialData);
+		expect(result.isPlaceholderData.value).toBe(false);
+	});
+
+	it('uses placeholderData when no initialData', () => {
+		const client = createQueryClient();
+		const placeholderData = {
+			pages: [[{ id: 99 }]],
+			pageParams: [99],
+		};
+
+		const result = useInfiniteQuery({
+			queryKey: ['items'],
+			queryFn: async () => [{ id: 1 }],
+			initialPageParam: 1,
+			getNextPageParam: () => undefined,
+			placeholderData,
+			enabled: false,
+			client,
+		});
+
+		expect(result.data.value).toEqual(placeholderData);
+		expect(result.isPlaceholderData.value).toBe(true);
+	});
+
+	it('applies select function to transform data', async () => {
+		const client = createQueryClient();
+		const result = useInfiniteQuery({
+			queryKey: ['items'],
+			queryFn: async ({ pageParam }) => ({ items: [{ id: pageParam }] }),
+			initialPageParam: 1,
+			getNextPageParam: () => undefined,
+			select: (data) => ({
+				pages: data.pages.map((page) => page.items),
+				pageParams: data.pageParams,
+			}),
+			client,
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(result.data.value?.pages).toEqual([[{ id: 1 }]]);
+	});
+
+	it('respects maxPages limit', async () => {
+		const client = createQueryClient();
+		const result = useInfiniteQuery({
+			queryKey: ['items'],
+			queryFn: async ({ pageParam }) => [{ id: pageParam }],
+			initialPageParam: 1,
+			getNextPageParam: (_lastPage, allPages) => allPages.length + 1,
+			maxPages: 2,
+			client,
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		await result.fetchNextPage();
+		await result.fetchNextPage();
+		await result.fetchNextPage();
+
+		expect(result.data.value?.pages).toHaveLength(2);
+	});
+
+	it('refetches from initial page', async () => {
+		const client = createQueryClient();
+		let pageParam = 0;
+		const result = useInfiniteQuery({
+			queryKey: ['items'],
+			queryFn: async ({ pageParam }) => {
+				return [{ id: pageParam }];
+			},
+			initialPageParam: 1,
+			getNextPageParam: (_lastPage, allPages) =>
+				allPages.length < 2 ? allPages.length + 1 : undefined,
+			client,
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		await result.fetchNextPage();
+		expect(result.data.value?.pages).toHaveLength(2);
+
+		await result.refetch();
+		expect(result.data.value?.pages).toHaveLength(1);
+		expect(result.data.value?.pages[0]).toEqual([{ id: 1 }]);
+	});
+
+	it('restores from cache on subsequent hook creation', async () => {
+		const client = createQueryClient();
+
+		const result1 = useInfiniteQuery({
+			queryKey: ['items'],
+			queryFn: async ({ pageParam }) => [{ id: pageParam }],
+			initialPageParam: 1,
+			getNextPageParam: () => undefined,
+			client,
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(result1.status.value).toBe('success');
+
+		const result2 = useInfiniteQuery({
+			queryKey: ['items'],
+			queryFn: async ({ pageParam }) => [{ id: pageParam }],
+			initialPageParam: 1,
+			getNextPageParam: () => undefined,
+			client,
+		});
+
+		expect(result2.status.value).toBe('success');
+		expect(result2.data.value?.pages).toEqual([[{ id: 1 }]]);
+	});
+});

--- a/packages/query/src/hooks/useInfiniteQuery.ts
+++ b/packages/query/src/hooks/useInfiniteQuery.ts
@@ -22,84 +22,85 @@
  * SOFTWARE.
  */
 
-import { Effect, Fiber, Duration, Predicate } from 'effect';
 import { signal, computed, type Signal, type ReadonlySignal } from '@effuse/core';
 import { useQueryClient, type QueryKey, type CacheEntry } from '../client/index.js';
-import { buildRetrySchedule, type RetryConfig } from '../execution/index.js';
 import { DEFAULT_STALE_TIME_MS, DEFAULT_TIMEOUT_MS } from '../config/index.js';
-import { InfiniteQueryError, TimeoutError } from '../errors/index.js';
+import { InfiniteQueryError } from '../errors/index.js';
 
-// Paginated query page data
-export interface InfiniteQueryPage<TData> {
-	readonly data: TData;
-}
-
-// Infinite query configuration
 export interface InfiniteQueryOptions<TData, TPageParam = number> {
 	readonly queryKey: QueryKey;
-	readonly queryFn: (context: { pageParam: TPageParam }) => Promise<TData>;
+	readonly queryFn: (context: { pageParam: TPageParam; signal: AbortSignal }) => Promise<TData>;
 	readonly initialPageParam: TPageParam;
 	readonly getNextPageParam: (
 		lastPage: TData,
-		allPages: TData[]
+		allPages: readonly TData[]
 	) => TPageParam | undefined;
 	readonly getPreviousPageParam?: (
 		firstPage: TData,
-		allPages: TData[]
+		allPages: readonly TData[]
 	) => TPageParam | undefined;
 	readonly staleTime?: number;
 	readonly timeout?: number;
-	readonly retry?: RetryConfig | number | boolean;
+	readonly retry?: number | boolean;
+	readonly retryDelay?: number;
 	readonly enabled?: boolean;
 	readonly maxPages?: number;
-	/**
-	 * Explicit QueryClient instance. If omitted, the hook will inject
-	 * from the nearest Effuse component scope via provideQueryClient(),
-	 * falling back to the global singleton.
-	 */
+	readonly select?: (data: InfiniteData<TData>) => InfiniteData<TData>;
+	readonly initialData?: InfiniteData<TData>;
+	readonly placeholderData?: InfiniteData<TData>;
+	readonly refetchOnWindowFocus?: boolean;
+	readonly refetchOnReconnect?: boolean;
 	readonly client?: import('../client/client.js').QueryClientApi;
 }
 
-// Infinite query result state
 export interface UseInfiniteQueryResult<TData> {
 	readonly data: Signal<InfiniteData<TData> | undefined>;
 	readonly error: Signal<Error | undefined>;
-
 	readonly status: Signal<'pending' | 'success' | 'error'>;
-	readonly isFetching: Signal<boolean>;
-	readonly isFetchingNextPage: Signal<boolean>;
-	readonly isFetchingPreviousPage: Signal<boolean>;
-	readonly hasNextPage: Signal<boolean>;
-	readonly hasPreviousPage: Signal<boolean>;
+	readonly fetchStatus: Signal<'idle' | 'fetching'>;
 
 	readonly isPending: ReadonlySignal<boolean>;
+	readonly isLoading: ReadonlySignal<boolean>;
 	readonly isSuccess: ReadonlySignal<boolean>;
 	readonly isError: ReadonlySignal<boolean>;
+	readonly isFetching: ReadonlySignal<boolean>;
+	readonly isRefetching: ReadonlySignal<boolean>;
+	readonly isPlaceholderData: ReadonlySignal<boolean>;
+
+	readonly isFetchingNextPage: ReadonlySignal<boolean>;
+	readonly isFetchingPreviousPage: ReadonlySignal<boolean>;
+	readonly hasNextPage: ReadonlySignal<boolean>;
+	readonly hasPreviousPage: ReadonlySignal<boolean>;
+
+	readonly dataUpdatedAt: Signal<number | undefined>;
+	readonly errorUpdatedAt: Signal<number | undefined>;
+	readonly failureCount: Signal<number>;
+	readonly failureReason: Signal<Error | undefined>;
 
 	readonly fetchNextPage: () => Promise<void>;
 	readonly fetchPreviousPage: () => Promise<void>;
 	readonly refetch: () => Promise<void>;
-
-	readonly allPagesData: ReadonlySignal<TData[] | undefined>;
+	readonly cancel: () => void;
 	readonly dispose: () => void;
 }
 
-// Infinite query page collection
 export interface InfiniteData<TData> {
 	readonly pages: TData[];
 	readonly pageParams: unknown[];
 }
 
+const sleep = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));
+
 const normalizeRetryConfig = (
-	retry: RetryConfig | number | boolean | undefined
-): RetryConfig | undefined => {
-	if (retry === false) return { times: 0 };
-	if (retry === true) return undefined;
-	if (typeof retry === 'number') return { times: retry };
-	return retry;
+	retry: number | boolean | undefined
+): number => {
+	if (retry === false) return 0;
+	if (retry === true) return 3;
+	if (typeof retry === 'number') return retry;
+	return 0;
 };
 
-// Reactive infinite query hook
 export const useInfiniteQuery = <TData, TPageParam = number>(
 	options: InfiniteQueryOptions<TData, TPageParam>
 ): UseInfiniteQueryResult<TData> => {
@@ -112,34 +113,43 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 		staleTime = DEFAULT_STALE_TIME_MS,
 		timeout = DEFAULT_TIMEOUT_MS,
 		retry,
+		retryDelay = 1000,
 		enabled = true,
 		maxPages,
+		select,
+		initialData,
+		placeholderData,
+		refetchOnWindowFocus = true,
+		refetchOnReconnect = true,
 	} = options;
 
 	const client = options.client ?? useQueryClient();
 
-	const dataSignal = signal<InfiniteData<TData> | undefined>(undefined);
+	const cacheKey = [...queryKey, 'infinite'];
+
+	const dataSignal = signal<InfiniteData<TData> | undefined>(initialData ?? placeholderData ?? undefined);
 	const errorSignal = signal<Error | undefined>(undefined);
-	const statusSignal = signal<'pending' | 'success' | 'error'>('pending');
-	const isFetchingSignal = signal<boolean>(false);
+	const statusSignal = signal<'pending' | 'success' | 'error'>(initialData ? 'success' : 'pending');
+	const fetchStatusSignal = signal<'idle' | 'fetching'>('idle');
 	const isFetchingNextPageSignal = signal<boolean>(false);
 	const isFetchingPreviousPageSignal = signal<boolean>(false);
 	const hasNextPageSignal = signal<boolean>(false);
 	const hasPreviousPageSignal = signal<boolean>(false);
+	const dataUpdatedAtSignal = signal<number | undefined>(initialData ? Date.now() : undefined);
+	const errorUpdatedAtSignal = signal<number | undefined>(undefined);
+	const failureCountSignal = signal<number>(0);
+	const failureReasonSignal = signal<Error | undefined>(undefined);
+	const isPlaceholderDataSignal = signal<boolean>(!!placeholderData && !initialData);
 
-	// Derived state — automatically reactive via computed()
 	const isPendingSignal = computed(() => statusSignal.value === 'pending');
+	const isLoadingSignal = computed(() => statusSignal.value === 'pending' && fetchStatusSignal.value === 'fetching');
 	const isSuccessSignal = computed(() => statusSignal.value === 'success');
 	const isErrorSignal = computed(() => statusSignal.value === 'error');
-	const allPagesDataSignal = computed(() => dataSignal.value?.pages);
+	const isFetchingSignal = computed(() => fetchStatusSignal.value === 'fetching');
+	const isRefetchingSignal = computed(() => dataSignal.value !== undefined && fetchStatusSignal.value === 'fetching');
 
-	let currentPageParams: TPageParam[] = [];
-
-	let activeFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
-
-	let isInternalUpdate = false;
-
-	const cacheKey = [...queryKey, 'infinite'];
+	let currentAbortController: AbortController | null = null;
+	let currentPageParams: TPageParam[] = initialData ? [...initialData.pageParams] as TPageParam[] : [];
 
 	const writeCache = (data: InfiniteData<TData>): void => {
 		const existing = client.get<InfiniteData<TData>>(cacheKey);
@@ -152,37 +162,61 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 		client.set(cacheKey, entry);
 	};
 
-	const fetchPage = (
-		pageParam: TPageParam
-	): Effect.Effect<TData, Error, never> => {
-		const retryConfig = normalizeRetryConfig(retry);
-		const schedule = buildRetrySchedule(retryConfig);
+	const runWithRetry = async (
+		pageParam: TPageParam,
+		maxRetries: number
+	): Promise<TData> => {
+		let lastError: Error | undefined;
+		currentAbortController = new AbortController();
+		const signal = currentAbortController.signal;
 
-		let effect: Effect.Effect<TData, Error, never> = Effect.tryPromise({
-			try: () => queryFn({ pageParam }),
-			catch: (error) =>
-				new InfiniteQueryError({
-					message: error instanceof Error ? error.message : String(error),
-					cause: error,
-				}),
-		});
+		for (let attempt = 0; attempt <= maxRetries; attempt++) {
+			if (signal.aborted) {
+				throw new Error('Query was cancelled');
+			}
 
-		effect = effect.pipe(
-			Effect.timeoutFail({
-				duration: Duration.millis(timeout),
-				onTimeout: () => new TimeoutError({ durationMs: timeout }),
-			})
-		);
+			try {
+				const promise = queryFn({ pageParam, signal });
 
-		if (!Predicate.isNotNullable(retryConfig) || retryConfig.times !== 0) {
-			effect = effect.pipe(Effect.retry(schedule));
+				if (timeout > 0) {
+					const timeoutPromise = new Promise<never>((_, reject) => {
+						const timer = setTimeout(() => {
+							reject(new Error(`Query timed out after ${timeout}ms`));
+						}, timeout);
+						signal.addEventListener('abort', () => {
+							clearTimeout(timer);
+							reject(new Error('Query was cancelled'));
+						});
+					});
+
+					return await Promise.race([promise, timeoutPromise]);
+				}
+
+				return await promise;
+			} catch (error) {
+				if (signal.aborted) {
+					throw new Error('Query was cancelled');
+				}
+
+				lastError = error instanceof Error ? error : new Error(String(error));
+
+				if (attempt < maxRetries) {
+					const delay = retryDelay * Math.pow(2, attempt);
+					await sleep(delay);
+				}
+			}
 		}
 
-		return effect;
+		throw lastError;
+	};
+
+	const fetchPage = async (pageParam: TPageParam): Promise<TData> => {
+		const maxRetries = normalizeRetryConfig(retry);
+		return runWithRetry(pageParam, maxRetries);
 	};
 
 	const fetchNextPage = async (): Promise<void> => {
-		if (!enabled || isFetchingSignal.value) return;
+		if (!enabled || fetchStatusSignal.value === 'fetching') return;
 
 		const currentData = dataSignal.value;
 		if (!currentData || currentData.pages.length === 0) {
@@ -204,41 +238,46 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 			return;
 		}
 
-		isFetchingSignal.value = true;
+		fetchStatusSignal.value = 'fetching';
 		isFetchingNextPageSignal.value = true;
 
 		try {
-			const newPage = await Effect.runPromise(fetchPage(nextPageParam));
+			const newPage = await fetchPage(nextPageParam);
 
-			isInternalUpdate = true;
 			const newData: InfiniteData<TData> = {
 				pages: [...currentData.pages, newPage],
 				pageParams: [...currentData.pageParams, nextPageParam],
 			};
 
-			dataSignal.value = newData;
+			const selectedData = select ? select(newData) : newData;
+			dataSignal.value = selectedData;
 			currentPageParams = [...currentPageParams, nextPageParam];
 
 			const nextNext = getNextPageParam(newPage, newData.pages);
 			hasNextPageSignal.value = nextNext !== undefined;
 
 			statusSignal.value = 'success';
+			isPlaceholderDataSignal.value = false;
+			dataUpdatedAtSignal.value = Date.now();
+			errorSignal.value = undefined;
+			failureCountSignal.value = 0;
+			failureReasonSignal.value = undefined;
 			writeCache(newData);
-			isInternalUpdate = false;
 		} catch (error) {
-			errorSignal.value =
-				error instanceof Error
-					? error
-					: new InfiniteQueryError({ message: String(error), cause: error });
+			const err = error instanceof Error ? error : new InfiniteQueryError({ message: String(error), cause: error });
+			errorSignal.value = err;
 			statusSignal.value = 'error';
+			errorUpdatedAtSignal.value = Date.now();
+			failureCountSignal.value += 1;
+			failureReasonSignal.value = err;
 		} finally {
-			isFetchingSignal.value = false;
+			fetchStatusSignal.value = 'idle';
 			isFetchingNextPageSignal.value = false;
 		}
 	};
 
 	const fetchPreviousPage = async (): Promise<void> => {
-		if (!enabled || isFetchingSignal.value || !getPreviousPageParam) return;
+		if (!enabled || fetchStatusSignal.value === 'fetching' || !getPreviousPageParam) return;
 
 		const currentData = dataSignal.value;
 		if (!currentData || currentData.pages.length === 0) {
@@ -255,35 +294,40 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 			return;
 		}
 
-		isFetchingSignal.value = true;
+		fetchStatusSignal.value = 'fetching';
 		isFetchingPreviousPageSignal.value = true;
 
 		try {
-			const newPage = await Effect.runPromise(fetchPage(prevPageParam));
+			const newPage = await fetchPage(prevPageParam);
 
-			isInternalUpdate = true;
 			const newData: InfiniteData<TData> = {
 				pages: [newPage, ...currentData.pages],
 				pageParams: [prevPageParam, ...currentData.pageParams],
 			};
 
-			dataSignal.value = newData;
+			const selectedData = select ? select(newData) : newData;
+			dataSignal.value = selectedData;
 			currentPageParams = [prevPageParam, ...currentPageParams];
 
 			const prevPrev = getPreviousPageParam(newPage, newData.pages);
 			hasPreviousPageSignal.value = prevPrev !== undefined;
 
 			statusSignal.value = 'success';
+			isPlaceholderDataSignal.value = false;
+			dataUpdatedAtSignal.value = Date.now();
+			errorSignal.value = undefined;
+			failureCountSignal.value = 0;
+			failureReasonSignal.value = undefined;
 			writeCache(newData);
-			isInternalUpdate = false;
 		} catch (error) {
-			errorSignal.value =
-				error instanceof Error
-					? error
-					: new InfiniteQueryError({ message: String(error), cause: error });
+			const err = error instanceof Error ? error : new InfiniteQueryError({ message: String(error), cause: error });
+			errorSignal.value = err;
 			statusSignal.value = 'error';
+			errorUpdatedAtSignal.value = Date.now();
+			failureCountSignal.value += 1;
+			failureReasonSignal.value = err;
 		} finally {
-			isFetchingSignal.value = false;
+			fetchStatusSignal.value = 'idle';
 			isFetchingPreviousPageSignal.value = false;
 		}
 	};
@@ -291,23 +335,19 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 	const refetch = async (): Promise<void> => {
 		if (!enabled) return;
 
-		if (activeFiber) {
-			Effect.runFork(Fiber.interrupt(activeFiber));
-			activeFiber = null;
-		}
-
-		isFetchingSignal.value = true;
+		cancel();
+		fetchStatusSignal.value = 'fetching';
 
 		try {
-			const initialPage = await Effect.runPromise(fetchPage(initialPageParam));
+			const initialPage = await fetchPage(initialPageParam);
 
-			isInternalUpdate = true;
 			const newData: InfiniteData<TData> = {
 				pages: [initialPage],
 				pageParams: [initialPageParam],
 			};
 
-			dataSignal.value = newData;
+			const selectedData = select ? select(newData) : newData;
+			dataSignal.value = selectedData;
 			currentPageParams = [initialPageParam];
 
 			const nextParam = getNextPageParam(initialPage, [initialPage]);
@@ -319,48 +359,93 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 			}
 
 			statusSignal.value = 'success';
+			isPlaceholderDataSignal.value = false;
+			dataUpdatedAtSignal.value = Date.now();
 			errorSignal.value = undefined;
+			failureCountSignal.value = 0;
+			failureReasonSignal.value = undefined;
 			writeCache(newData);
-			isInternalUpdate = false;
 		} catch (error) {
-			errorSignal.value =
-				error instanceof Error
-					? error
-					: new InfiniteQueryError({ message: String(error), cause: error });
+			const err = error instanceof Error ? error : new InfiniteQueryError({ message: String(error), cause: error });
+			errorSignal.value = err;
 			statusSignal.value = 'error';
+			errorUpdatedAtSignal.value = Date.now();
+			failureCountSignal.value += 1;
+			failureReasonSignal.value = err;
 		} finally {
-			isFetchingSignal.value = false;
+			fetchStatusSignal.value = 'idle';
 		}
 	};
 
-	const cached = client.get<InfiniteData<TData>>(cacheKey);
-	if (cached) {
-		dataSignal.value = cached.data;
+	const cancel = (): void => {
+		if (currentAbortController) {
+			currentAbortController.abort();
+			currentAbortController = null;
+		}
+	};
 
+	// Initialize from cache
+	const cached = client.get<InfiniteData<TData>>(cacheKey);
+	if (cached && cached.data) {
+		dataSignal.value = cached.data;
 		if (cached.status === 'success') {
 			statusSignal.value = 'success';
+			dataUpdatedAtSignal.value = cached.dataUpdatedAt;
 		} else if (cached.status === 'error') {
 			statusSignal.value = 'error';
-		} else {
-			statusSignal.value = 'pending';
+		}
+
+		const pages = cached.data.pages;
+		if (pages.length > 0) {
+			const lastPage = pages[pages.length - 1]!;
+			const nextParam = getNextPageParam(lastPage, pages);
+			hasNextPageSignal.value = nextParam !== undefined;
+
+			if (getPreviousPageParam) {
+				const firstPage = pages[0]!;
+				const prevParam = getPreviousPageParam(firstPage, pages);
+				hasPreviousPageSignal.value = prevParam !== undefined;
+			}
 		}
 	}
 
-	const unsubscribe = client.subscribe(cacheKey, () => {
-		if (enabled && !isInternalUpdate) {
-			refetch();
-		}
-	});
-
-	if (enabled && (!cached || client.isStale(cacheKey, staleTime))) {
+	// Initial fetch
+	if (enabled && !initialData && (!cached || client.isStale(cacheKey, staleTime))) {
 		refetch();
 	}
 
+	// Window focus refetch
+	const cleanupFns: Array<() => void> = [];
+
+	if (refetchOnWindowFocus && typeof window !== 'undefined') {
+		const handleFocus = (): void => {
+			if (enabled && (!cached || client.isStale(cacheKey, staleTime))) {
+				refetch().catch(() => {
+					// Errors handled internally
+				});
+			}
+		};
+		window.addEventListener('focus', handleFocus);
+		cleanupFns.push(() => window.removeEventListener('focus', handleFocus));
+	}
+
+	// Reconnect refetch
+	if (refetchOnReconnect && typeof window !== 'undefined') {
+		const handleOnline = (): void => {
+			if (enabled && (!cached || client.isStale(cacheKey, staleTime))) {
+				refetch().catch(() => {
+					// Errors handled internally
+				});
+			}
+		};
+		window.addEventListener('online', handleOnline);
+		cleanupFns.push(() => window.removeEventListener('online', handleOnline));
+	}
+
 	const dispose = (): void => {
-		unsubscribe();
-		if (activeFiber) {
-			Effect.runFork(Fiber.interrupt(activeFiber));
-			activeFiber = null;
+		cancel();
+		for (const fn of cleanupFns) {
+			fn();
 		}
 	};
 
@@ -368,18 +453,26 @@ export const useInfiniteQuery = <TData, TPageParam = number>(
 		data: dataSignal,
 		error: errorSignal,
 		status: statusSignal,
+		fetchStatus: fetchStatusSignal,
+		isPending: isPendingSignal,
+		isLoading: isLoadingSignal,
+		isSuccess: isSuccessSignal,
+		isError: isErrorSignal,
 		isFetching: isFetchingSignal,
+		isRefetching: isRefetchingSignal,
+		isPlaceholderData: isPlaceholderDataSignal,
 		isFetchingNextPage: isFetchingNextPageSignal,
 		isFetchingPreviousPage: isFetchingPreviousPageSignal,
 		hasNextPage: hasNextPageSignal,
 		hasPreviousPage: hasPreviousPageSignal,
-		isPending: isPendingSignal,
-		isSuccess: isSuccessSignal,
-		isError: isErrorSignal,
+		dataUpdatedAt: dataUpdatedAtSignal,
+		errorUpdatedAt: errorUpdatedAtSignal,
+		failureCount: failureCountSignal,
+		failureReason: failureReasonSignal,
 		fetchNextPage,
 		fetchPreviousPage,
 		refetch,
-		allPagesData: allPagesDataSignal,
+		cancel,
 		dispose,
 	};
 };

--- a/packages/query/src/hooks/useIsFetching.ts
+++ b/packages/query/src/hooks/useIsFetching.ts
@@ -44,7 +44,7 @@ export const useIsFetching = (options?: UseIsFetchingOptions): ReadonlySignal<nu
 
 	updateCount();
 
-	const unsubscribe = client.queryCache.subscribe(updateCount);
+	void client.queryCache.subscribe(updateCount);
 
 	const result = computed(() => countSignal.value);
 

--- a/packages/query/src/hooks/useIsMutating.ts
+++ b/packages/query/src/hooks/useIsMutating.ts
@@ -43,7 +43,7 @@ export const useIsMutating = (options?: UseIsMutatingOptions): ReadonlySignal<nu
 
 	updateCount();
 
-	const unsubscribe = client.mutationCache.subscribe(updateCount);
+	void client.mutationCache.subscribe(updateCount);
 
 	const result = computed(() => countSignal.value);
 	return result;

--- a/packages/query/src/hooks/useMutation.ts
+++ b/packages/query/src/hooks/useMutation.ts
@@ -349,8 +349,8 @@ export interface OptimisticQueryConfig<TData, TVariables> {
 	) => TData;
 }
 
-// Options for optimistic mutation
-export interface OptimisticMutationOptions<TData, TVariables> {
+// Options for optimistic mutation hook
+export interface OptimisticMutationHookOptions<TData, TVariables> {
 	readonly mutationFn: (variables: TVariables) => Promise<TData>;
 	/** Queries to optimistically update. */
 	readonly queries: ReadonlyArray<OptimisticQueryConfig<TData, TVariables>>;
@@ -369,7 +369,7 @@ interface OptimisticContext<TData> {
 
 // Optimistic update hook
 export const useOptimisticMutation = <TData, TVariables>(
-	options: OptimisticMutationOptions<TData, TVariables>
+	options: OptimisticMutationHookOptions<TData, TVariables>
 ): UseMutationResult<TData, TVariables, OptimisticContext<TData>> => {
 	const {
 		mutationFn,

--- a/packages/query/src/hooks/usePrefetch.ts
+++ b/packages/query/src/hooks/usePrefetch.ts
@@ -23,11 +23,7 @@
  */
 
 import { Predicate, Option, pipe } from 'effect';
-import {
-	useQueryClient,
-	getGlobalQueryClient,
-	type QueryKey,
-} from '../client/index.js';
+import { useQueryClient, type QueryKey } from '../client/index.js';
 import type { QueryClientApi } from '../client/client.js';
 import { DEFAULT_STALE_TIME_MS } from '../config/index.js';
 
@@ -37,8 +33,12 @@ export interface PrefetchOptions {
 	readonly client?: QueryClientApi;
 }
 
-const resolveClient = (options?: PrefetchOptions): QueryClientApi =>
-	options?.client ?? getGlobalQueryClient();
+const resolveClient = (options?: PrefetchOptions): QueryClientApi => {
+	if (options?.client) return options.client;
+	throw new Error(
+		'prefetchQuery requires a client. Pass it via options.client or use within a QueryClientProvider.'
+	);
+};
 
 // Prefetch query data
 export const prefetchQuery = <T>(

--- a/packages/query/src/hooks/useQuery.ts
+++ b/packages/query/src/hooks/useQuery.ts
@@ -133,27 +133,27 @@ export const useQuery = <TData>(
 	const query = client.getQuery<TData, Error>({
 		queryKey,
 		queryFn: wrapQueryFn(queryFn),
-		staleTime,
-		gcTime: cacheTime,
-		retry,
-		timeout,
+		...(staleTime !== undefined && { staleTime }),
+		...(cacheTime !== undefined && { gcTime: cacheTime }),
+		...(retry !== undefined && { retry }),
+		...(timeout !== undefined && { timeout }),
 	});
 
 	// Create the observer
 	const observer = new QueryObserver(query, {
 		queryKey,
 		queryFn: wrapQueryFn(queryFn),
-		staleTime,
-		gcTime: cacheTime,
-		retry,
-		timeout,
+		...(staleTime !== undefined && { staleTime }),
+		...(cacheTime !== undefined && { gcTime: cacheTime }),
+		...(retry !== undefined && { retry }),
+		...(timeout !== undefined && { timeout }),
 		enabled,
-		select,
-		placeholderData,
-		initialData,
+		...(select !== undefined && { select }),
+		...(placeholderData !== undefined && { placeholderData }),
+		...(initialData !== undefined && { initialData }),
 		refetchOnWindowFocus,
 		refetchOnReconnect,
-		refetchInterval,
+		...(refetchInterval !== false && { refetchInterval }),
 	});
 
 	// Sync signals from observer result

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -87,14 +87,13 @@ export type {
 	MutationStatus,
 	MutateOptions,
 	OptimisticMutationOptions,
+	OptimisticMutationHookOptions,
 	UseQueriesOptions,
 	UseQueriesResult,
 	CombinedQueryResult,
 	InfiniteQueryOptions,
 	UseInfiniteQueryResult,
 	InfiniteData,
-	InfiniteQueryPage,
-	PrefetchOptions,
 } from './hooks/index.js';
 
 export {

--- a/packages/query/src/utils/createQueryKeys.ts
+++ b/packages/query/src/utils/createQueryKeys.ts
@@ -28,7 +28,7 @@ type KeyDefinition = null | ((...args: readonly unknown[]) => readonly unknown[]
 
 type KeyOutput<TKey extends string, TDef extends KeyDefinition> = TDef extends null
 	? readonly [TKey, string]
-	: TDef extends (...args: infer A) => infer R
+	: TDef extends (...args: infer _A) => infer R
 		? R extends readonly unknown[]
 			? readonly [TKey, string, ...R]
 			: never
@@ -37,7 +37,7 @@ type KeyOutput<TKey extends string, TDef extends KeyDefinition> = TDef extends n
 type KeyFactory<TKey extends string, TDefs extends Record<string, KeyDefinition>> = {
 	readonly [K in keyof TDefs & string]: TDefs[K] extends null
 		? () => KeyOutput<TKey, TDefs[K]>
-		: TDefs[K] extends (...args: infer A) => infer R
+		: TDefs[K] extends (...args: infer A) => infer _R
 			? (...args: A) => KeyOutput<TKey, TDefs[K]>
 			: never;
 };


### PR DESCRIPTION
## Summary

- Major improvements to `useInfiniteQuery` hook
- Comprehensive integration test suite using https://jsonplaceholder.typicode.com/
- TypeScript compilation fixes across the query package

## useInfiniteQuery Improvements

- Removed Effect from execution path — pure Promise-based with AbortController
- Added `fetchStatus` signal (`idle` | `fetching`)
- Added `isLoading`, `isRefetching`, `isPlaceholderData` signals
- Added `dataUpdatedAt`, `errorUpdatedAt`, `failureCount`, `failureReason`
- Added `cancel()` function with AbortSignal propagation
- Added `select` support for data transformation
- Added `initialData` and `placeholderData` support
- Added `refetchOnWindowFocus` and `refetchOnReconnect`
- Retry with exponential backoff via plain Promises
- Timeout support via `Promise.race`
- Proper `maxPages` enforcement

## Integration Test Suite

`jsonplaceholder-integration.test.ts` exercises all major query functionality against live API:

- `useQuery` — fetch posts, users, comments
- `useMutation` — create posts with state tracking
- `useInfiniteQuery` — paginated post fetching
- `useIsFetching` — global fetching state tracking
- `useIsMutating` — global mutation state tracking
- `createQueryKeys` — type-safe key generation
- Query cache operations — `setQueryData`, `removeQueries`, `invalidate`
- Mutation cache operations — `build`, shared instances
- Prefetching — `prefetchQuery`, `fetchQuery`
- Dehydration / hydration — round-trip cache state
- End-to-end workflow — full user journey

## Type Fixes

- Fixed `TError` constraint to `extends Error` in `Mutation` and `MutationCache`
- Removed unused type parameters from `QueryConfig`, `QueryObserver`, `MutationObserver`
- Fixed `exactOptionalPropertyTypes` violations in `useQuery`, `hydration.ts`
- Renamed conflicting `OptimisticMutationOptions` to `OptimisticMutationHookOptions`
- Fixed `usePrefetch.ts` to require explicit `client` (removed broken global singleton fallback)

## Tests

- Full suite: **261 tests passing** (up from 241)
- TypeScript compilation: **zero errors**